### PR TITLE
A graphic representation for the Contig class

### DIFF
--- a/tests/YEplac195_snapgene.gb
+++ b/tests/YEplac195_snapgene.gb
@@ -1,0 +1,184 @@
+LOCUS       .                       5241 bp    DNA     circular UNK 01-JAN-1980
+DEFINITION  .
+ACCESSION   <unknown id>
+VERSION     <unknown id>
+KEYWORDS    .
+SOURCE
+  ORGANISM  .
+            .
+COMMENT     pydna cdseguid=nsxZh92qaUyjufyG0goiB3-Aq8c 2024-06-11T18:43:06
+FEATURES             Location/Qualifiers
+     rep_origin      745..2091
+                     /note="yeast 2μ plasmid origin of replication"
+                     /note="color: #ffff00"
+                     /label="2μ ori"
+     promoter        complement(3004..3224)
+                     /gene="S. cerevisiae URA3"
+                     /label="URA3 promoter"
+                     /note="color: #ffffff"
+     CDS             complement(2200..3003)
+                     /codon_start=1
+                     /gene="S. cerevisiae URA3"
+                     /note="yeast auxotrophic marker, counterselectable with
+                     5-fluoroorotic acid (5-FOA)"
+                     /note="color: #ff7f50"
+                     /product="orotidine-5'-phosphate decarboxylase, required
+                     for uracil biosynthesis"
+                     /transl_table=1
+                     /translation="MSKATYKERAATHPSPVAAKLFNIMHEKQTNLCASLDVRTTKELL
+                     ELVEALGPKICLLKTHVDILTDFSMEGTVKPLKALSAKYNFLLFEDRKFADIGNTVKLQ
+                     YSAGVYRIAEWADITNAHGVVGPGIVSGLKQAAEEVTKEPRGLLMLAELSCKGSLSTGE
+                     YTKGTVDIAKSDKDFVIGFIAQRDMGGRDEGYDWLIMTPGVGLDDKGDALGQQYRTVDD
+                     VVSTGSDIIIVGRGLFAKGRDAKVEGERYRKAGWEAYLRRCGQQN*"
+                     /label="URA3"
+     protein_bind    180..196
+                     /bound_moiety="lac repressor encoded by lacI"
+                     /note="The lac repressor binds to the lac operator to
+                     inhibit transcription in E. coli. This inhibition can be
+                     relieved by adding lactose or
+                     isopropyl-β-D-thiogalactopyranoside (IPTG)."
+                     /note="color: #31849b"
+                     /label="lac operator"
+     primer_bind     204..220
+                     /note="common sequencing primer, one of multiple similar
+                     variants"
+                     /note="color: #a020f0"
+                     /label="M13 rev"
+     primer_bind     complement(290..306)
+                     /note="common sequencing primer, one of multiple similar
+                     variants"
+                     /note="color: #a020f0"
+                     /label="M13 fwd"
+     promoter        142..172
+                     /note="promoter for the E. coli lac operon"
+                     /note="color: #ffffff"
+                     /label="lac promoter"
+     misc_feature    233..289
+                     /gene=""
+                     /note="pUC19 multiple cloning site"
+                     /note="color: #99ccff"
+                     /label="MCS"
+     promoter        3335..3439
+                     /gene="bla"
+                     /label="AmpR promoter"
+                     /note="color: #ffffff"
+     CDS             216..500
+                     /codon_start=1
+                     /gene="lacZ"
+                     /product="LacZα fragment of β-galactosidase"
+                     /transl_table=1
+                     /translation="MTMITPSLHACRSTLEDPRVPSSNSLAVVLQRRDWENPGVTQLNR
+                     LAAHPPFASWRNSEEARTDRPSQQLRSLNGEWRLMRYFLLTHLCGISHRI"
+                     /label="lacZα"
+                     /note="color: #993366"
+     rep_origin      4471..5059
+                     /direction=RIGHT
+                     /note="high-copy-number colE1/pMB1/pBR322/pUC origin of
+                     replication"
+                     /note="color: #ffff00"
+                     /label="ori"
+     CDS             3440..4300
+                     /codon_start=1
+                     /gene="bla"
+                     /note="confers resistance to ampicillin, carbenicillin, and
+                     related antibiotics"
+                     /note="color: #ccffcc"
+                     /product="β-lactamase"
+                     /transl_table=1
+                     /translation="MSIQHFRVALIPFFAAFCLPVFA,HPETLVKVKDAEDQLGARVGY
+                     IELDLNSGKILESFRPEERFPMMSTFKVLLCGAVLSRIDAGQEQLGRRIHYSQNDLVEY
+                     SPVTEKHLTDGMTVRELCSAAITMSDNTAANLLLTTIGGPKELTAFLHNMGDHVTRLDR
+                     WEPELNEAIPNDERDTTMPVAMATTLRKLLTGELLTLASRQQLIDWMEADKVAGPLLRS
+                     ALPAGWFIADKSGAGERGSRGIIAALGPDGKPSRIVVIYTTGSQATMDERNRQIAEIGA
+                     SLIKHW*"
+                     /label="AmpR"
+ORIGIN
+        1 gcgcccaata cgcaaaccgc ctctccccgc gcgttggccg attcattaat gcagctggca
+       61 cgacaggttt cccgactgga aagcgggcag tgagcgcaac gcaattaatg tgagttagct
+      121 cactcattag gcaccccagg ctttacactt tatgcttccg gctcgtatgt tgtgtggaat
+      181 tgtgagcgga taacaatttc acacaggaaa cagctatgac catgattacg ccaagcttgc
+      241 atgcctgcag gtcgactcta gaggatcccc gggtaccgag ctcgaattca ctggccgtcg
+      301 ttttacaacg tcgtgactgg gaaaaccctg gcgttaccca acttaatcgc cttgcagcac
+      361 atcccccttt cgccagctgg cgtaatagcg aagaggcccg caccgatcgc ccttcccaac
+      421 agttgcgcag cctgaatggc gaatggcgcc tgatgcggta ttttctcctt acgcatctgt
+      481 gcggtatttc acaccgcata tatcggatcg tacttgttac ccatcattga attttgaaca
+      541 tccgaacctg ggagttttcc ctgaaacaga tagtatattt gaacctgtat aataatatat
+      601 agtctagcgc tttacggaag acaatgtatg tatttcggtt cctggagaaa ctattgcatc
+      661 tattgcatag gtaatcttgc acgtcgcatc cccggttcat tttctgcgtt tccatcttgc
+      721 acttcaatag catatctttg ttaacgaagc atctgtgctt cattttgtag aacaaaaatg
+      781 caacgcgaga gcgctaattt ttcaaacaaa gaatctgagc tgcattttta cagaacagaa
+      841 atgcaacgcg aaagcgctat tttaccaacg aagaatctgt gcttcatttt tgtaaaacaa
+      901 aaatgcaacg cgagagcgct aatttttcaa acaaagaatc tgagctgcat ttttacagaa
+      961 cagaaatgca acgcgagagc gctattttac caacaaagaa tctatacttc ttttttgttc
+     1021 tacaaaaatg catcccgaga gcgctatttt tctaacaaag catcttagat tacttttttt
+     1081 ctcctttgtg cgctctataa tgcagtctct tgataacttt ttgcactgta ggtccgttaa
+     1141 ggttagaaga aggctacttt ggtgtctatt ttctcttcca taaaaaaagc ctgactccac
+     1201 ttcccgcgtt tactgattac tagcgaagct gcgggtgcat tttttcaaga taaaggcatc
+     1261 cccgattata ttctataccg atgtggattg cgcatacttt gtgaacagaa agtgatagcg
+     1321 ttgatgattc ttcattggtc agaaaattat gaacggtttc ttctattttg tctctatata
+     1381 ctacgtatag gaaatgttta cattttcgta ttgttttcga ttcactctat gaatagttct
+     1441 tactacaatt tttttgtcta aagagtaata ctagagataa acataaaaaa tgtagaggtc
+     1501 gagtttagat gcaagttcaa ggagcgaaag gtggatgggt aggttatata gggatatagc
+     1561 acagagatat atagcaaaga gatacttttg agcaatgttt gtggaagcgg tattcgcaat
+     1621 attttagtag ctcgttacag tccggtgcgt ttttggtttt ttgaaagtgc gtcttcagag
+     1681 cgcttttggt tttcaaaagc gctctgaagt tcctatactt tctagctaga gaataggaac
+     1741 ttcggaatag gaacttcaaa gcgtttccga aaacgagcgc ttccgaaaat gcaacgcgag
+     1801 ctgcgcacat acagctcact gttcacgtcg cacctatatc tgcgtgttgc ctgtatatat
+     1861 atatacatga gaagaacggc atagtgcgtg tttatgctta aatgcgtact tatatgcgtc
+     1921 tatttatgta ggatgaaagg tagtctagta cctcctgtga tattatccca ttccatgcgg
+     1981 ggtatcgtat gcttccttca gcactaccct ttagctgttc tatatgctgc cactcctcaa
+     2041 ttggattagt ctcatccttc aatgctatca tttcctttga tattggatcg atccgatgat
+     2101 aagctgtcaa acatgagaat tgggtaataa ctgatataat taaattgaag ctctaatttg
+     2161 tgagtttagt atacatgcat ttacttataa tacagttttt tagttttgct ggccgcatct
+     2221 tctcaaatat gcttcccagc ctgcttttct gtaacgttca ccctctacct tagcatccct
+     2281 tccctttgca aatagtcctc ttccaacaat aataatgtca gatcctgtag agaccacatc
+     2341 atccacggtt ctatactgtt gacccaatgc gtctcccttg tcatctaaac ccacaccggg
+     2401 tgtcataatc aaccaatcgt aaccttcatc tcttccaccc atgtctcttt gagcaataaa
+     2461 gccgataaca aaatctttgt cgctcttcgc aatgtcaaca gtacccttag tatattctcc
+     2521 agtagatagg gagcccttgc atgacaattc tgctaacatc aaaaggcctc taggttcctt
+     2581 tgttacttct tctgccgcct gcttcaaacc gctaacaata cctgggccca ccacaccgtg
+     2641 tgcattcgta atgtctgccc attctgctat tctgtataca cccgcagagt actgcaattt
+     2701 gactgtatta ccaatgtcag caaattttct gtcttcgaag agtaaaaaat tgtacttggc
+     2761 ggataatgcc tttagcggct taactgtgcc ctccatggaa aaatcagtca agatatccac
+     2821 atgtgttttt agtaaacaaa ttttgggacc taatgcttca actaactcca gtaattcctt
+     2881 ggtggtacga acatccaatg aagcacacaa gtttgtttgc ttttcgtgca tgatattaaa
+     2941 tagcttggca gcaacaggac taggatgagt agcagcacgt tccttatatg tagctttcga
+     3001 catgatttat cttcgtttcc tgcatgtttt tgttctgtgc agttgggtta agaatactgg
+     3061 gcaatttcat gtttcttcaa cactacatat gcgtatatat accaatctaa gtctgtgctc
+     3121 cttccttcgt tcttccttct gttcggagat taccgaatca aaaaaatttc aaagaaaccg
+     3181 aaatcaaaaa aaagaataaa aaaaaaatga tgaattgaat tgaaaagcta attcttgaag
+     3241 acgaaagggc ctcgtgatac gcctattttt ataggttaat gtcatgataa taatggtttc
+     3301 ttagacgtca ggtggcactt ttcggggaaa tgtgcgcgga acccctattt gtttattttt
+     3361 ctaaatacat tcaaatatgt atccgctcat gagacaataa ccctgataaa tgcttcaata
+     3421 atattgaaaa aggaagagta tgagtattca acatttccgt gtcgccctta ttcccttttt
+     3481 tgcggcattt tgccttcctg tttttgctca cccagaaacg ctggtgaaag taaaagatgc
+     3541 tgaagatcag ttgggtgcac gagtgggtta catcgaactg gatctcaaca gcggtaagat
+     3601 ccttgagagt tttcgccccg aagaacgttt tccaatgatg agcactttta aagttctgct
+     3661 atgtggcgcg gtattatccc gtattgacgc cgggcaagag caactcggtc gccgcataca
+     3721 ctattctcag aatgacttgg ttgagtactc accagtcaca gaaaagcatc ttacggatgg
+     3781 catgacagta agagaattat gcagtgctgc cataaccatg agtgataaca ctgcggccaa
+     3841 cttacttctg acaacgatcg gaggaccgaa ggagctaacc gcttttttgc acaacatggg
+     3901 ggatcatgta actcgccttg atcgttggga accggagctg aatgaagcca taccaaacga
+     3961 cgagcgtgac accacgatgc ctgtagcaat ggcaacaacg ttgcgcaaac tattaactgg
+     4021 cgaactactt actctagctt cccggcaaca attaatagac tggatggagg cggataaagt
+     4081 tgcaggacca cttctgcgct cggcccttcc ggctggctgg tttattgctg ataaatctgg
+     4141 agccggtgag cgtgggtctc gcggtatcat tgcagcactg gggccagatg gtaagccctc
+     4201 ccgtatcgta gttatctaca cgacggggag tcaggcaact atggatgaac gaaatagaca
+     4261 gatcgctgag ataggtgcct cactgattaa gcattggtaa ctgtcagacc aagtttactc
+     4321 atatatactt tagattgatt taaaacttca tttttaattt aaaaggatct aggtgaagat
+     4381 cctttttgat aatctcatga ccaaaatccc ttaacgtgag ttttcgttcc actgagcgtc
+     4441 agaccccgta gaaaagatca aaggatcttc ttgagatcct ttttttctgc gcgtaatctg
+     4501 ctgcttgcaa acaaaaaaac caccgctacc agcggtggtt tgtttgccgg atcaagagct
+     4561 accaactctt tttccgaagg taactggctt cagcagagcg cagataccaa atactgttct
+     4621 tctagtgtag ccgtagttag gccaccactt caagaactct gtagcaccgc ctacatacct
+     4681 cgctctgcta atcctgttac cagtggctgc tgccagtggc gataagtcgt gtcttaccgg
+     4741 gttggactca agacgatagt taccggataa ggcgcagcgg tcgggctgaa cggggggttc
+     4801 gtgcacacag cccagcttgg agcgaacgac ctacaccgaa ctgagatacc tacagcgtga
+     4861 gctatgagaa agcgccacgc ttcccgaagg gagaaaggcg gacaggtatc cggtaagcgg
+     4921 cagggtcgga acaggagagc gcacgaggga gcttccaggg ggaaacgcct ggtatcttta
+     4981 tagtcctgtc gggtttcgcc acctctgact tgagcgtcga tttttgtgat gctcgtcagg
+     5041 ggggcggagc ctatggaaaa acgccagcaa cgcggccttt ttacggttcc tggccttttg
+     5101 ctggcctttt gctcacatgt tctttcctgc gttatcccct gattctgtgg ataaccgtat
+     5161 taccgccttt gagtgagctg ataccgctcg ccgcagccga acgaccgagc gcagcgagtc
+     5221 agtgagcgag gaagcggaag a
+//

--- a/tests/YIplac204_snapgene.gb
+++ b/tests/YIplac204_snapgene.gb
@@ -1,0 +1,157 @@
+LOCUS       .                       3545 bp    DNA     circular UNK 01-JAN-1980
+DEFINITION  .
+ACCESSION   <unknown id>
+VERSION     <unknown id>
+KEYWORDS    .
+SOURCE
+  ORGANISM  .
+            .
+COMMENT     pydna cdseguid=24fcVzVrHWTQXwerHr3_OyEw9D0 2024-06-11T18:43:03
+FEATURES             Location/Qualifiers
+     promoter        complement(1450..1551)
+                     /gene="S. cerevisiae TRP1"
+                     /label="TRP1 promoter"
+                     /note="color: #ffffff"
+     CDS             complement(775..1449)
+                     /codon_start=1
+                     /gene="S. cerevisiae TRP1"
+                     /note="yeast auxotrophic marker"
+                     /note="color: #ff7f50"
+                     /product="phosphoribosylanthranilate isomerase, required
+                     for tryptophan biosynthesis"
+                     /transl_table=1
+                     /translation="MSVINFTGSSGPLVKVCGLQSTEAAECALDSDADLLGIICVPNRK
+                     RTIDPVIARKISSLVKAYKNSSGTPKYLVGVFRNQPKEDVLALVNDYGIDIVQLHGDES
+                     WQEYQEFLGLPVIKRLVFPKDCNILLSAASQKPHSFIPLFDSEAGGTGELLDWNSISDW
+                     VGRQESPESLHFMLAGGLTPENVGDALRLNGVIGVDVSGGVETNGVKDSNKIANFVKNA
+                     KK*"
+                     /label="TRP1"
+     rep_origin      696..936
+                     /note="S. cerevisiae autonomously replicating sequence
+                     ARS1/ARS416"
+                     /note="color: #ffff00"
+                     /label="ARS1"
+     protein_bind    180..196
+                     /bound_moiety="lac repressor encoded by lacI"
+                     /note="The lac repressor binds to the lac operator to
+                     inhibit transcription in E. coli. This inhibition can be
+                     relieved by adding lactose or
+                     isopropyl-β-D-thiogalactopyranoside (IPTG)."
+                     /note="color: #31849b"
+                     /label="lac operator"
+     primer_bind     204..220
+                     /note="common sequencing primer, one of multiple similar
+                     variants"
+                     /note="color: #a020f0"
+                     /label="M13 rev"
+     primer_bind     complement(290..306)
+                     /note="common sequencing primer, one of multiple similar
+                     variants"
+                     /note="color: #a020f0"
+                     /label="M13 fwd"
+     promoter        142..172
+                     /note="promoter for the E. coli lac operon"
+                     /note="color: #ffffff"
+                     /label="lac promoter"
+     misc_feature    233..289
+                     /gene=""
+                     /note="pUC19 multiple cloning site"
+                     /note="color: #99ccff"
+                     /label="MCS"
+     promoter        1639..1743
+                     /gene="bla"
+                     /label="AmpR promoter"
+                     /note="color: #ffffff"
+     CDS             216..539
+                     /codon_start=1
+                     /gene="lacZ"
+                     /product="LacZα fragment of β-galactosidase"
+                     /transl_table=1
+                     /translation="MTMITPSLHACRSTLEDPRVPSSNSLAVVLQRRDWENPGVTQLNR
+                     LAAHPPFASWRNSEEARTDRPSQQLRSLNGEWRLMRYFLLTHLCGISHRIWCTLSTICS
+                     DAA*"
+                     /label="lacZα"
+                     /note="color: #993366"
+     rep_origin      2775..3363
+                     /direction=RIGHT
+                     /note="high-copy-number colE1/pMB1/pBR322/pUC origin of
+                     replication"
+                     /note="color: #ffff00"
+                     /label="ori"
+     CDS             1744..2604
+                     /codon_start=1
+                     /gene="bla"
+                     /note="confers resistance to ampicillin, carbenicillin, and
+                     related antibiotics"
+                     /note="color: #ccffcc"
+                     /product="β-lactamase"
+                     /transl_table=1
+                     /translation="MSIQHFRVALIPFFAAFCLPVFA,HPETLVKVKDAEDQLGARVGY
+                     IELDLNSGKILESFRPEERFPMMSTFKVLLCGAVLSRIDAGQEQLGRRIHYSQNDLVEY
+                     SPVTEKHLTDGMTVRELCSAAITMSDNTAANLLLTTIGGPKELTAFLHNMGDHVTRLDR
+                     WEPELNEAIPNDERDTTMPVAMATTLRKLLTGELLTLASRQQLIDWMEADKVAGPLLRS
+                     ALPAGWFIADKSGAGERGSRGIIAALGPDGKPSRIVVIYTTGSQATMDERNRQIAEIGA
+                     SLIKHW*"
+                     /label="AmpR"
+ORIGIN
+        1 gcgcccaata cgcaaaccgc ctctccccgc gcgttggccg attcattaat gcagctggca
+       61 cgacaggttt cccgactgga aagcgggcag tgagcgcaac gcaattaatg tgagttagct
+      121 cactcattag gcaccccagg ctttacactt tatgcttccg gctcgtatgt tgtgtggaat
+      181 tgtgagcgga taacaatttc acacaggaaa cagctatgac catgattacg ccaagcttgc
+      241 atgcctgcag gtcgactcta gaggatcccc gggtaccgag ctcgaattca ctggccgtcg
+      301 ttttacaacg tcgtgactgg gaaaaccctg gcgttaccca acttaatcgc cttgcagcac
+      361 atcccccttt cgccagctgg cgtaatagcg aagaggcccg caccgatcgc ccttcccaac
+      421 agttgcgcag cctgaatggc gaatggcgcc tgatgcggta ttttctcctt acgcatctgt
+      481 gcggtatttc acaccgcata tggtgcactc tcagtacaat ctgctctgat gccgcatagt
+      541 taagccagcc ccgacacccg ccaacacccg ctgacgcgcc ctgacgggct tgtctgctcc
+      601 cggcatccgc ttacagacaa gctgtgaccg tctccgggag ctgcatgtgt cagaggtttt
+      661 caccgtcatc accgaaacgc gcgagacgaa agggcgatct tttatgcttg cttttcaaaa
+      721 ggcttgcagg caagtgcaca aacaatactt aaataaatac tactcagtaa taacctattt
+      781 cttagcattt ttgacgaaat ttgctatttt gttagagtct tttacaccat ttgtctccac
+      841 acctccgctt acatcaacac caataacgcc atttaatcta agcgcatcac caacattttc
+      901 tggcgtcagt ccaccagcta acataaaatg taagctctcg gggctctctt gccttccaac
+      961 ccagtcagaa atcgagttcc aatccaaaag ttcacctgtc ccacctgctt ctgaatcaaa
+     1021 caagggaata aacgaatgag gtttctgtga agctgcactg agtagtatgt tgcagtcttt
+     1081 tggaaatacg agtcttttaa taactggcaa accgaggaac tcttggtatt cttgccacga
+     1141 ctcatctcca tgcagttgga cgatatcaat gccgtaatca ttgaccagag ccaaaacatc
+     1201 ctccttaggt tgattacgaa acacgccaac caagtatttc ggagtgcctg aactattttt
+     1261 atatgctttt acaagacttg aaattttcct tgcaataacc gggtcaattg ttctctttct
+     1321 attgggcaca catataatac ccagcaagtc agcatcggaa tctagtgcac attctgcggc
+     1381 ctctgtgctc tgcaagccgc aaactttcac caatggacca gaactacctg tgaaattaat
+     1441 aacagacata ctccaagctg cctttgtgtg cttaatcacg tatactcacg tgctcaatag
+     1501 tcaccaatgc cctccctctt ggccctctcc ttttcttttt tcgaccgaat tggcctcgtg
+     1561 atacgcctat ttttataggt taatgtcatg ataataatgg tttcttagac gtcaggtggc
+     1621 acttttcggg gaaatgtgcg cggaacccct atttgtttat ttttctaaat acattcaaat
+     1681 atgtatccgc tcatgagaca ataaccctga taaatgcttc aataatattg aaaaaggaag
+     1741 agtatgagta ttcaacattt ccgtgtcgcc cttattccct tttttgcggc attttgcctt
+     1801 cctgtttttg ctcacccaga aacgctggtg aaagtaaaag atgctgaaga tcagttgggt
+     1861 gcacgagtgg gttacatcga actggatctc aacagcggta agatccttga gagttttcgc
+     1921 cccgaagaac gttttccaat gatgagcact tttaaagttc tgctatgtgg cgcggtatta
+     1981 tcccgtattg acgccgggca agagcaactc ggtcgccgca tacactattc tcagaatgac
+     2041 ttggttgagt actcaccagt cacagaaaag catcttacgg atggcatgac agtaagagaa
+     2101 ttatgcagtg ctgccataac catgagtgat aacactgcgg ccaacttact tctgacaacg
+     2161 atcggaggac cgaaggagct aaccgctttt ttgcacaaca tgggggatca tgtaactcgc
+     2221 cttgatcgtt gggaaccgga gctgaatgaa gccataccaa acgacgagcg tgacaccacg
+     2281 atgcctgtag caatggcaac aacgttgcgc aaactattaa ctggcgaact acttactcta
+     2341 gcttcccggc aacaattaat agactggatg gaggcggata aagttgcagg accacttctg
+     2401 cgctcggccc ttccggctgg ctggtttatt gctgataaat ctggagccgg tgagcgtggg
+     2461 tctcgcggta tcattgcagc actggggcca gatggtaagc cctcccgtat cgtagttatc
+     2521 tacacgacgg ggagtcaggc aactatggat gaacgaaata gacagatcgc tgagataggt
+     2581 gcctcactga ttaagcattg gtaactgtca gaccaagttt actcatatat actttagatt
+     2641 gatttaaaac ttcattttta atttaaaagg atctaggtga agatcctttt tgataatctc
+     2701 atgaccaaaa tcccttaacg tgagttttcg ttccactgag cgtcagaccc cgtagaaaag
+     2761 atcaaaggat cttcttgaga tccttttttt ctgcgcgtaa tctgctgctt gcaaacaaaa
+     2821 aaaccaccgc taccagcggt ggtttgtttg ccggatcaag agctaccaac tctttttccg
+     2881 aaggtaactg gcttcagcag agcgcagata ccaaatactg ttcttctagt gtagccgtag
+     2941 ttaggccacc acttcaagaa ctctgtagca ccgcctacat acctcgctct gctaatcctg
+     3001 ttaccagtgg ctgctgccag tggcgataag tcgtgtctta ccgggttgga ctcaagacga
+     3061 tagttaccgg ataaggcgca gcggtcgggc tgaacggggg gttcgtgcac acagcccagc
+     3121 ttggagcgaa cgacctacac cgaactgaga tacctacagc gtgagctatg agaaagcgcc
+     3181 acgcttcccg aagggagaaa ggcggacagg tatccggtaa gcggcagggt cggaacagga
+     3241 gagcgcacga gggagcttcc agggggaaac gcctggtatc tttatagtcc tgtcgggttt
+     3301 cgccacctct gacttgagcg tcgatttttg tgatgctcgt caggggggcg gagcctatgg
+     3361 aaaaacgcca gcaacgcggc ctttttacgg ttcctggcct tttgctggcc ttttgctcac
+     3421 atgttctttc ctgcgttatc ccctgattct gtggataacc gtattaccgc ctttgagtga
+     3481 gctgataccg ctcgccgcag ccgaacgacc gagcgcagcg agtcagtgag cgaggaagcg
+     3541 gaaga
+//

--- a/tests/pBR322.gb
+++ b/tests/pBR322.gb
@@ -1,0 +1,472 @@
+LOCUS       SYNPBR322               4361 bp    DNA     circular SYN 30-SEP-2008
+DEFINITION  Cloning vector pBR322, complete sequence.
+ACCESSION   J01749
+VERSION     J01749.1
+KEYWORDS    ampicillin resistance; beta-lactamase; cloning vector; drug
+            resistance protein; origin of replication; plasmid; tetracycline
+            resistance.
+SOURCE      Cloning vector pBR322
+  ORGANISM  Cloning vector pBR322
+            other sequences; artificial sequences; vectors.
+REFERENCE   1
+  AUTHORS   Sutcliffe,J.G.
+  TITLE     Nucleotide sequence of the ampicillin resistance gene of Escherichia
+            coli plasmid pBR322
+  JOURNAL   Proc. Natl. Acad. Sci. U.S.A. 75 (8), 3737-3741 (1978)
+   PUBMED   358200
+REFERENCE   2  (bases 1 to 4361)
+  AUTHORS   Sutcliffe,J.G.
+  TITLE     Complete nucleotide sequence of the Escherichia coli plasmid pBR322
+  JOURNAL   Cold Spring Harb. Symp. Quant. Biol. 43 (Pt 1), 77-90 (1979)
+   PUBMED   383387
+REFERENCE   3  (bases 1500 to 2300)
+  AUTHORS   Reed,R.R., Young,R.A., Steitz,J.A., Grindley,N.D. and Guyer,M.S.
+  TITLE     Transposition of the Escherichia coli insertion element gamma
+            generates a five-base-pair repeat
+  JOURNAL   Proc. Natl. Acad. Sci. U.S.A. 76 (10), 4882-4886 (1979)
+   PUBMED   388421
+REFERENCE   4  (bases 2207 to 2265)
+  AUTHORS   Covarrubias,L., Cervantes,L., Covarrubias,A., Soberon,X.,
+            Vichido,I., Blanco,A., Kupersztoch-Portnoy,Y.M. and Bolivar,F.
+  TITLE     Construction and characterization of new cloning vehicles. V.
+            Mobilization and coding properties of pBR322 and several deletion
+            derivatives including pBR327 and pBR328
+  JOURNAL   Gene 13 (1), 25-35 (1981)
+   PUBMED   6263753
+REFERENCE   5  (bases 2000 to 2500)
+  AUTHORS   Marians,K.J., Soeller,W. and Zipursky,S.L.
+  TITLE     Maximal limits of the Escherichia coli replication factor Y effector
+            site sequences in pBR322 DNA
+  JOURNAL   J. Biol. Chem. 257 (10), 5656-5662 (1982)
+   PUBMED   6279609
+REFERENCE   6
+  AUTHORS   Brosius,J., Cate,R.L. and Perlmutter,A.P.
+  TITLE     Precise location of two promoters for the beta-lactamase gene of
+            pBR322. S1 mapping of ribonucleic acid isolated from Escherichia
+            coli or synthesized in vitro
+  JOURNAL   J. Biol. Chem. 257 (15), 9205-9210 (1982)
+   PUBMED   6178738
+REFERENCE   7  (bases 4241 to 4343)
+  AUTHORS   Van Dyke,M.W., Hertzberg,R.P. and Dervan,P.B.
+  TITLE     Map of distamycin, netropsin, and actinomycin binding sites on
+            heterogeneous DNA: DNA cleavage-inhibition patterns with
+            methidiumpropyl-EDTA.Fe(II)
+  JOURNAL   Proc. Natl. Acad. Sci. U.S.A. 79 (18), 5470-5474 (1982)
+   PUBMED   6291045
+REFERENCE   8  (bases 584 to 709)
+  AUTHORS   Peden,K.W. and Nathans,D.
+  TITLE     Local mutagenesis within deletion loops of DNA heteroduplexes
+  JOURNAL   Proc. Natl. Acad. Sci. U.S.A. 79 (23), 7214-7217 (1982)
+   PUBMED   6760191
+REFERENCE   9  (bases 373 to 649)
+  AUTHORS   Peden,K.W.
+  TITLE     Revised sequence of the tetracycline-resistance gene of pBR322
+  JOURNAL   Gene 22 (2-3), 277-280 (1983)
+   PUBMED   6307828
+REFERENCE   10  (bases 132 to 181)
+  AUTHORS   Watabe,H., Iino,T., Kaneko,T., Shibata,T. and Ando,T.
+  TITLE     A new class of site-specific endodeoxyribonucleases. Endo.Sce I
+            isolated from a eukaryote, Saccharomyces cerevisiae
+  JOURNAL   J. Biol. Chem. 258 (8), 4663-4665 (1983)
+   PUBMED   6300094
+REFERENCE   11  (bases 368 to 581)
+  AUTHORS   Livneh,Z.
+  TITLE     Directed mutagenesis method for analysis of mutagen specificity:
+            application to ultraviolet-induced mutagenesis
+  JOURNAL   Proc. Natl. Acad. Sci. U.S.A. 80 (1), 237-241 (1983)
+   PUBMED   6337373
+REFERENCE   12
+  AUTHORS   Mascharak,P.K., Sugiura,Y., Kuwahara,J., Suzuki,T. and Lippard,S.J.
+  TITLE     Alteration and activation of sequence-specific cleavage of DNA by
+            bleomycin in the presence of the antitumor drug
+            cis-diamminedichloroplatinum(II)
+  JOURNAL   Proc. Natl. Acad. Sci. U.S.A. 80 (22), 6795-6798 (1983)
+   PUBMED   6196777
+REFERENCE   13  (bases 4276 to 4336)
+  AUTHORS   Schultz,P.G. and Dervan,P.B.
+  TITLE     Sequence-specific double-strand cleavage of DNA by
+            penta-N-methylpyrrolecarboxamide-EDTA X Fe(II)
+  JOURNAL   Proc. Natl. Acad. Sci. U.S.A. 80 (22), 6834-6837 (1983)
+   PUBMED   6417654
+REFERENCE   14  (bases 518 to 528)
+  AUTHORS   Sutcliffe,J.G.
+  JOURNAL   Unpublished
+REFERENCE   15  (bases 2395 to 2495)
+  AUTHORS   Fuller,R.S., Funnell,B.E. and Kornberg,A.
+  TITLE     The dnaA protein complex with the E. coli chromosomal replication
+            origin (oriC) and other DNA sites
+  JOURNAL   Cell 38 (3), 889-900 (1984)
+   PUBMED   6091903
+REFERENCE   16  (bases 2729 to 2731)
+  AUTHORS   Lathe,R., Kieny,M.P., Skory,S. and Lecocq,J.P.
+  TITLE     Linker tailing: unphosphorylated linker oligonucleotides for joining
+            DNA termini
+  JOURNAL   DNA 3 (2), 173-182 (1984)
+   PUBMED   6327214
+REFERENCE   17  (bases 2729 to 2730)
+  AUTHORS   Heusterspreute,M. and Davison,J.
+  TITLE     Restriction site bank vectors. II. DNA sequence analysis of plasmid
+            pJRD158
+  JOURNAL   DNA 3 (3), 259-268 (1984)
+   PUBMED   6086259
+REFERENCE   18
+  AUTHORS   Abarzua,P., Soeller,W. and Marians,K.J.
+  TITLE     Mutational analysis of primosome assembly sites. I. Distinct classes
+            of mutants in the pBR322 Escherichia coli factor Y DNA effector
+            sequences
+  JOURNAL   J. Biol. Chem. 259 (22), 14286-14292 (1984)
+   PUBMED   6209275
+REFERENCE   19  (bases 2348 to 2415)
+  AUTHORS   Soeller,W., Abarzua,P. and Marians,K.J.
+  TITLE     Mutational analysis of primosome assembly sites. II. Role of
+            secondary structure in the formation of active sites
+  JOURNAL   J. Biol. Chem. 259 (22), 14293-14300 (1984)
+   PUBMED   6150042
+REFERENCE   20  (bases 1 to 4361)
+  AUTHORS   Van Dyke,M.M. and Dervan,P.B.
+  TITLE     Echinomycin binding sites on DNA
+  JOURNAL   Science 225 (4667), 1122-1127 (1984)
+   PUBMED   6089341
+REFERENCE   21
+  AUTHORS   Pouwels,P.H., Enger-Valk,B.E. and Brammar,W.J.
+  JOURNAL   (in) CLONING VECTORS. Elsevier Scientific Publishing, Amsterdam
+            (1985)
+  REMARK    Vector I-A-iv-1
+REFERENCE   22  (bases 1 to 4361)
+  AUTHORS   Watson,N.
+  TITLE     A new revision of the sequence of plasmid pBR322
+  JOURNAL   Gene 70 (2), 399-403 (1988)
+   PUBMED   3063608
+REFERENCE   23
+  AUTHORS   Gilbert,W.
+  TITLE     Obtained from VecBase 3.0
+  JOURNAL   Unpublished
+COMMENT     On or before Apr 4, 2002 this sequence version replaced L08654.1,
+            gi:58257.
+            The circular sequence is numbered such that 0 is the middle of the
+            unique EcoRI site and the count increases first through the tet
+            genes, the pMB1 material, and finally through the Tn3 region.
+            Plasmid pBR322 contains ampicillin and tetracycline resistance
+            genes.  The ampicillin resistance gene (amp-r) is a penicillin
+            beta-lactamase. Promoters P1 and P3 are for the beta-lactamase
+            gene. P3 is the natural promoter, and P1 is artificially created by
+            the ligation of two different DNA fragments to create pBR322. P2 is
+            in the same region as P1, but it is on the opposite strand and
+            initiates transcription in the direction of the tetracycline
+            resistance gene.
+            Mutational studies in the primosome assembly sites indicate four
+            types of mutations:  Class I having no effect on the activities
+            elicited by the DNA site and the bases involved are probably
+            spacers; Class II requiring higher Mg-2+ concentrations than the
+            wild-type to be fully activated as factor Y ATPase effectors; Class
+            III co-inactivating both the ATPase effector and DNA replication
+            template activity of the site, indicating that they probably
+            represent essential contact points between factor Y and the DNA;
+            Class IV having a replication template activity intermediate that
+            of class III and class II mutant DNAs.
+            Specific sites within or near the origins of replication are
+            recognized by dnaA protein.  Without dnaA binding to the origin of
+            replication chromosomal replication is not possible (15). pBR322
+            DNA contains two separate regions on opposite strands and close to
+            the origin of replication which, when in single-stranded form, can
+            act as effectors for the ATPase activity of E.coli replication
+            factor Y (5).  Small fragments of DNA containing these sites when
+            cloned in an f1 phage vector act as origins of DNA replication
+            allowing the formation of complementary double-stranded DNA in
+            rifampicin-resistant, dna(B,G,C)-dependent fashion in vitro (5).
+            The biological activity of echinomycin is thought to be related to
+            the formation of complexes by intercalating with cellular DNA (20).
+            Complete source information:
+            Plasmid pBR322 from E.coli (2),(1),(3),(6),(11),(8),(5),(7),(12),
+            (13),(10),(9),(14),(18),(19),(15),(20),(16); pBR322 DNA in pXf3
+            (4).
+            The following data and their annotation were supplied by Will
+            Gilbert under the auspices of the Curator Program.
+            CROSSREFERENCE
+            #parent
+            GenBank(50):pSC101C, GenBank(50):Trn3
+            #offspring
+            VecBase(3):pBR325, VecBase(3):pBR327,
+            VecBase(3):pBR328,
+            VecBase(3):pAT153, VecBase(3):pUC7,
+            VecBase(3):pJRD158,
+            VecBase(3):PiVX, VecBase(3):PiAN7,
+            VecBase(3):pSP64,
+            VecBase(3):pSP65, VecBase(3):pGEM1,
+            VecBase(3):pGEM2,
+            VecBase(3):pGEM3, VecBase(3):pGEM4,
+            VecBase(3):pKK223,
+            VecBase(3):pLBU3, VecBase(3):pTrS3,
+            VecBase(3):pRSVNeo,
+            VecBase(3):pSV2Cat, VecBase(3):M13mp9,
+            VecBase(3):pHC79,
+            VecBase(3):pV34, VecBase(3):pKTH601,
+            VecBase(3):pKTH604,
+            VecBase(3):pKTH605, VecBase(3):pKTH606,
+            VecBase(3):YEp24,
+            VecBase(3):YIp5, VecBase(3):YRp17,
+            VecBase(3):pSP18,
+            VecBase(3):pSP19,
+            VecBase(3):pSP6T3, VecBase(3):pSP6T719,
+            VecBase(3):pT712,
+            VecBase(3):pT713, VecBase(3):pT7T318,
+            VecBase(3):pT7T319,
+            VecBase(3):pT7T3A18, VecBase(3):pT7T3A19,
+            VecBase(3):pEX1,
+            VecBase(3):pEX2, VecBase(3):pEX3,
+            VecBase(3):pCKSP6,
+            VecBase(3):pACYC177, VecBase(3):pKO1,
+            VecBase(3):pKO2,
+            VecBase(3):pKM1,
+            VecBase(3):pKM2, VecBase(3):pMBL1,
+            VecBase(3):pMBL604,
+            VecBase(3):pMC1511, VecBase(3):pMC1871,
+            VecBase(3):pAA37X,
+            VecBase(3):pUR278, VecBase(3):pUR288,
+            VecBase(3):pUR289,
+            VecBase(3):pUR290, VecBase(3):pUR291,
+            VecBase(3):pUR292,
+            VecBase(3):pUR222.
+            pydna cdseguid=H-FY2ZzvKeazrRW2dNeSeMikjoc 2024-06-11T18:53:45
+FEATURES             Location/Qualifiers
+     source          1..4361
+                     /organism="Cloning vector pBR322"
+                     /mol_type="other DNA"
+                     /db_xref="taxon:47470"
+                     /tissue_lib="ATCC 31344, ATCC 37017"
+                     /focus=""
+     source          1..1762
+                     /organism="Plasmid pSC101"
+                     /mol_type="other DNA"
+                     /db_xref="taxon:2625"
+     misc_binding    24..27
+                     /bound_moiety="echinomycin"
+     regulatory      complement(27..33)
+                     /regulatory_class="promoter"
+                     /note="promoter P1 (6)"
+     misc_binding    39..42
+                     /bound_moiety="echinomycin"
+     regulatory      43..49
+                     /regulatory_class="promoter"
+                     /note="promoter P2 (6)"
+     misc_binding    53..56
+                     /bound_moiety="echinomycin"
+     misc_binding    67..70
+                     /bound_moiety="echinomycin"
+     misc_binding    80..83
+                     /bound_moiety="echinomycin"
+     gene            86..1276
+                     /gene="tet"
+     CDS             86..1276
+                     /gene="tet"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="tetracycline resistance protein"
+                     /protein_id="AAB59735.1"
+                     /translation="MKSNNALIVILGTVTLDAVGIGLVMPVLPGLLRDIVHSDSIASHY
+                     GVLLALYALMQFLCAPVLGALSDRFGRRPVLLASLLGATIDYAIMATTPVLWILYAGRI
+                     VAGITGATGAVAGAYIADITDGEDRARHFGLMSACFGVGMVAGPVAGGLLGAISLHAPF
+                     LAAAVLNGLNLLLGCFLMQESHKGERRPMPLRAFNPVSSFRWARGMTIVAALMTVFFIM
+                     QLVGQVPAALWVIFGEDRFRWSATMIGLSLAVFGILHALAQAFVTGPATKRFGEKQAII
+                     AGMAADALGYVLLAFATRGWMAFPIMILLASGGIGMPALQAMLSRQVDDDHQGQLQGSL
+                     AALTSLTSITGPLIVTAIYAASASTWNGLAWIVGAALYLVCLPALRRGAWSRATST"
+     misc_feature    complement(141..142)
+                     /note="Endo.Sce I cleavage site coordinated with site at
+                     base 146 (10)"
+     misc_feature    146..147
+                     /gene="tet"
+                     /note="Endo.Sce I cleavage site coordinated with site at
+                     base 142 (10)"
+     misc_binding    411..414
+                     /gene="tet"
+                     /bound_moiety="echinomycin"
+     misc_difference 426
+                     /gene="tet"
+                     /note="conflict"
+                     /citation=[11]
+                     /replace=""
+     misc_binding    469..472
+                     /gene="tet"
+                     /bound_moiety="echinomycin"
+     old_sequence    526..528
+                     /gene="tet"
+                     /citation=[17]
+     repeat_region   complement(1515..1519)
+                     /note="gamma-delta insertion target sequence"
+                     /rpt_type=direct
+     misc_feature    1636..1762
+                     /note="from pSC101 (bp 1860-1986)"
+     repeat_region   complement(1788..1792)
+                     /note="gamma-delta insertion target sequence"
+                     /rpt_type=direct
+     misc_difference 1891..1892
+                     /note="conflict"
+                     /citation=[23]
+                     /replace="att"
+     old_sequence    1892..1893
+                     /citation=[2]
+                     /citation=[22]
+     regulatory      1905..1910
+                     /regulatory_class="ribosome_binding_site"
+     regulatory      1905..1909
+                     /regulatory_class="ribosome_binding_site"
+                     /note="Shine-Dalgarno sequence"
+     misc_difference 1913..1914
+                     /note="conflict"
+                     /citation=[23]
+                     /replace="caa"
+     old_sequence    1914..1915
+                     /citation=[17]
+     CDS             1915..2106
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ROP protein"
+                     /protein_id="AAB59736.1"
+                     /translation="MTKQEKTALNMARFIRSQTLTLLEKLNELDADEQADICESLHDHA
+                     DELYRSCLARFGDDGENL"
+     misc_feature    2011..2167
+                     /note="H-strand Y effector site"
+                     /citation=[5]
+     repeat_region   complement(2245..2249)
+                     /note="gamma-delta insertion target sequence"
+                     /rpt_type=direct
+     misc_feature    complement(2351..2414)
+                     /note="L-strand Y effector site"
+                     /citation=[5]
+     misc_binding    2439..2447
+                     /bound_moiety="dnaA"
+     rep_origin      2535
+     old_sequence    2729..2730
+                     /note="revision according to (17)"
+                     /citation=[2]
+                     /citation=[17]
+                     /replace="at"
+     old_sequence    2729
+                     /citation=[17]
+     old_sequence    2730
+                     /note="revision according to (16)"
+                     /citation=[2]
+                     /citation=[16]
+                     /citation=[17]
+                     /replace="t"
+     mobile_element  3148..4361
+                     /mobile_element_type="transposon:Tn3"
+     repeat_region   3148..3185
+                     /note="corresponds to one of the 38bp repeats found in Tn3
+                     (bp 1-38 and complement (4920-4957))"
+                     /rpt_type=inverted
+     gene            complement(3293..4153)
+                     /gene="bla"
+     CDS             complement(3293..4153)
+                     /gene="bla"
+                     /note="E-286"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="beta-lactamase"
+                     /protein_id="AAB59737.1"
+                     /translation="MSIQHFRVALIPFFAAFCLPVFAHPETLVKVKDAEDQLGARVGYI
+                     ELDLNSGKILESFRPEERFPMMSTFKVLLCGAVLSRVDAGQEQLGRRIHYSQNDLVEYS
+                     PVTEKHLTDGMTVRELCSAAITMSDNTAANLLLTTIGGPKELTAFLHNMGDHVTRLDRW
+                     EPELNEAIPNDERDTTMPAAMATTLRKLLTGELLTLASRQQLIDWMEADKVAGPLLRSA
+                     LPAGWFIADKSGAGERGSRGIIAALGPDGKPSRIVVIYTTGSQATMDERNRQIAEIGAS
+                     LIKHW"
+     sig_peptide     complement(4085..4153)
+                     /gene="bla"
+     mat_peptide     complement(3296..4084)
+                     /gene="bla"
+                     /product="beta-lactamase"
+     regulatory      complement(4161..4165)
+                     /regulatory_class="ribosome_binding_site"
+                     /note="Shine-Dalgarno sequence"
+     regulatory      complement(4188..4194)
+                     /regulatory_class="promoter"
+                     /note="promoter P3 (6)"
+     misc_binding    complement(4268..4271)
+                     /bound_moiety="echinomycin"
+     misc_binding    complement(4280..4283)
+                     /bound_moiety="echinomycin"
+     misc_binding    complement(4285..4288)
+                     /bound_moiety="echinomycin"
+     misc_binding    complement(4296..4299)
+                     /bound_moiety="echinomycin"
+     misc_binding    complement(4311..4314)
+                     /bound_moiety="echinomycin"
+     misc_binding    complement(4317..4320)
+                     /bound_moiety="echinomycin"
+     misc_binding    complement(4331..4334)
+                     /bound_moiety="echinomycin"
+ORIGIN
+        1 ttctcatgtt tgacagctta tcatcgataa gctttaatgc ggtagtttat cacagttaaa
+       61 ttgctaacgc agtcaggcac cgtgtatgaa atctaacaat gcgctcatcg tcatcctcgg
+      121 caccgtcacc ctggatgctg taggcatagg cttggttatg ccggtactgc cgggcctctt
+      181 gcgggatatc gtccattccg acagcatcgc cagtcactat ggcgtgctgc tagcgctata
+      241 tgcgttgatg caatttctat gcgcacccgt tctcggagca ctgtccgacc gctttggccg
+      301 ccgcccagtc ctgctcgctt cgctacttgg agccactatc gactacgcga tcatggcgac
+      361 cacacccgtc ctgtggatcc tctacgccgg acgcatcgtg gccggcatca ccggcgccac
+      421 aggtgcggtt gctggcgcct atatcgccga catcaccgat ggggaagatc gggctcgcca
+      481 cttcgggctc atgagcgctt gtttcggcgt gggtatggtg gcaggccccg tggccggggg
+      541 actgttgggc gccatctcct tgcatgcacc attccttgcg gcggcggtgc tcaacggcct
+      601 caacctacta ctgggctgct tcctaatgca ggagtcgcat aagggagagc gtcgaccgat
+      661 gcccttgaga gccttcaacc cagtcagctc cttccggtgg gcgcggggca tgactatcgt
+      721 cgccgcactt atgactgtct tctttatcat gcaactcgta ggacaggtgc cggcagcgct
+      781 ctgggtcatt ttcggcgagg accgctttcg ctggagcgcg acgatgatcg gcctgtcgct
+      841 tgcggtattc ggaatcttgc acgccctcgc tcaagccttc gtcactggtc ccgccaccaa
+      901 acgtttcggc gagaagcagg ccattatcgc cggcatggcg gccgacgcgc tgggctacgt
+      961 cttgctggcg ttcgcgacgc gaggctggat ggccttcccc attatgattc ttctcgcttc
+     1021 cggcggcatc gggatgcccg cgttgcaggc catgctgtcc aggcaggtag atgacgacca
+     1081 tcagggacag cttcaaggat cgctcgcggc tcttaccagc ctaacttcga tcactggacc
+     1141 gctgatcgtc acggcgattt atgccgcctc ggcgagcaca tggaacgggt tggcatggat
+     1201 tgtaggcgcc gccctatacc ttgtctgcct ccccgcgttg cgtcgcggtg catggagccg
+     1261 ggccacctcg acctgaatgg aagccggcgg cacctcgcta acggattcac cactccaaga
+     1321 attggagcca atcaattctt gcggagaact gtgaatgcgc aaaccaaccc ttggcagaac
+     1381 atatccatcg cgtccgccat ctccagcagc cgcacgcggc gcatctcggg cagcgttggg
+     1441 tcctggccac gggtgcgcat gatcgtgctc ctgtcgttga ggacccggct aggctggcgg
+     1501 ggttgcctta ctggttagca gaatgaatca ccgatacgcg agcgaacgtg aagcgactgc
+     1561 tgctgcaaaa cgtctgcgac ctgagcaaca acatgaatgg tcttcggttt ccgtgtttcg
+     1621 taaagtctgg aaacgcggaa gtcagcgccc tgcaccatta tgttccggat ctgcatcgca
+     1681 ggatgctgct ggctaccctg tggaacacct acatctgtat taacgaagcg ctggcattga
+     1741 ccctgagtga tttttctctg gtcccgccgc atccataccg ccagttgttt accctcacaa
+     1801 cgttccagta accgggcatg ttcatcatca gtaacccgta tcgtgagcat cctctctcgt
+     1861 ttcatcggta tcattacccc catgaacaga aatccccctt acacggaggc atcagtgacc
+     1921 aaacaggaaa aaaccgccct taacatggcc cgctttatca gaagccagac attaacgctt
+     1981 ctggagaaac tcaacgagct ggacgcggat gaacaggcag acatctgtga atcgcttcac
+     2041 gaccacgctg atgagcttta ccgcagctgc ctcgcgcgtt tcggtgatga cggtgaaaac
+     2101 ctctgacaca tgcagctccc ggagacggtc acagcttgtc tgtaagcgga tgccgggagc
+     2161 agacaagccc gtcagggcgc gtcagcgggt gttggcgggt gtcggggcgc agccatgacc
+     2221 cagtcacgta gcgatagcgg agtgtatact ggcttaacta tgcggcatca gagcagattg
+     2281 tactgagagt gcaccatatg cggtgtgaaa taccgcacag atgcgtaagg agaaaatacc
+     2341 gcatcaggcg ctcttccgct tcctcgctca ctgactcgct gcgctcggtc gttcggctgc
+     2401 ggcgagcggt atcagctcac tcaaaggcgg taatacggtt atccacagaa tcaggggata
+     2461 acgcaggaaa gaacatgtga gcaaaaggcc agcaaaaggc caggaaccgt aaaaaggccg
+     2521 cgttgctggc gtttttccat aggctccgcc cccctgacga gcatcacaaa aatcgacgct
+     2581 caagtcagag gtggcgaaac ccgacaggac tataaagata ccaggcgttt ccccctggaa
+     2641 gctccctcgt gcgctctcct gttccgaccc tgccgcttac cggatacctg tccgcctttc
+     2701 tcccttcggg aagcgtggcg ctttctcata gctcacgctg taggtatctc agttcggtgt
+     2761 aggtcgttcg ctccaagctg ggctgtgtgc acgaaccccc cgttcagccc gaccgctgcg
+     2821 ccttatccgg taactatcgt cttgagtcca acccggtaag acacgactta tcgccactgg
+     2881 cagcagccac tggtaacagg attagcagag cgaggtatgt aggcggtgct acagagttct
+     2941 tgaagtggtg gcctaactac ggctacacta gaaggacagt atttggtatc tgcgctctgc
+     3001 tgaagccagt taccttcgga aaaagagttg gtagctcttg atccggcaaa caaaccaccg
+     3061 ctggtagcgg tggttttttt gtttgcaagc agcagattac gcgcagaaaa aaaggatctc
+     3121 aagaagatcc tttgatcttt tctacggggt ctgacgctca gtggaacgaa aactcacgtt
+     3181 aagggatttt ggtcatgaga ttatcaaaaa ggatcttcac ctagatcctt ttaaattaaa
+     3241 aatgaagttt taaatcaatc taaagtatat atgagtaaac ttggtctgac agttaccaat
+     3301 gcttaatcag tgaggcacct atctcagcga tctgtctatt tcgttcatcc atagttgcct
+     3361 gactccccgt cgtgtagata actacgatac gggagggctt accatctggc cccagtgctg
+     3421 caatgatacc gcgagaccca cgctcaccgg ctccagattt atcagcaata aaccagccag
+     3481 ccggaagggc cgagcgcaga agtggtcctg caactttatc cgcctccatc cagtctatta
+     3541 attgttgccg ggaagctaga gtaagtagtt cgccagttaa tagtttgcgc aacgttgttg
+     3601 ccattgctgc aggcatcgtg gtgtcacgct cgtcgtttgg tatggcttca ttcagctccg
+     3661 gttcccaacg atcaaggcga gttacatgat cccccatgtt gtgcaaaaaa gcggttagct
+     3721 ccttcggtcc tccgatcgtt gtcagaagta agttggccgc agtgttatca ctcatggtta
+     3781 tggcagcact gcataattct cttactgtca tgccatccgt aagatgcttt tctgtgactg
+     3841 gtgagtactc aaccaagtca ttctgagaat agtgtatgcg gcgaccgagt tgctcttgcc
+     3901 cggcgtcaac acgggataat accgcgccac atagcagaac tttaaaagtg ctcatcattg
+     3961 gaaaacgttc ttcggggcga aaactctcaa ggatcttacc gctgttgaga tccagttcga
+     4021 tgtaacccac tcgtgcaccc aactgatctt cagcatcttt tactttcacc agcgtttctg
+     4081 ggtgagcaaa aacaggaagg caaaatgccg caaaaaaggg aataagggcg acacggaaat
+     4141 gttgaatact catactcttc ctttttcaat attattgaag catttatcag ggttattgtc
+     4201 tcatgagcgg atacatattt gaatgtattt agaaaaataa acaaataggg gttccgcgca
+     4261 catttccccg aaaagtgcca cctgacgtct aagaaaccat tattatcatg acattaacct
+     4321 ataaaaatag gcgtatcacg aggccctttc gtcttcaaga a
+//

--- a/tests/pYPKpw.gb
+++ b/tests/pYPKpw.gb
@@ -1,0 +1,483 @@
+LOCUS       pYPKpw                  5603 bp    DNA     circular SYN 01-JAN-1980
+DEFINITION  pcr_product_866_pYPKpwF (39-mer)_865_pYPKpwR (39-mer)
+            cSEGUID_WeyovdMmqwA4bc9EqEwUDmbo3Lg.
+ACCESSION   .
+VERSION     .
+KEYWORDS    .
+SOURCE
+  ORGANISM  .
+            .
+COMMENT     Annotated with pLannotate v1.2.0
+            pydna cdseguid=xj7evEO4h83-RGFeHu8q15tL_Qs 2024-06-11T18:53:45
+FEATURES             Location/Qualifiers
+     primer_bind     complement(96..124)
+                     /label="865_pYPKpwR"
+                     /ApEinfo_fwdcolor="#baffa3"
+                     /ApEinfo_revcolor="#ffbaba"
+     primer_bind     144..173
+                     /label="866_pYPKpwF"
+                     /ApEinfo_fwdcolor="#baffa3"
+                     /ApEinfo_revcolor="#ffbaba"
+     promoter        complement(292..311)
+                     /note="pLannotate"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="44.4"
+                     /fragment="True"
+                     /other="promoter"
+                     /locus_tag="T5 promoter (fragment)"
+                     /label="T5 promoter (fragment)"
+                     /ApEinfo_label="T5 promoter (fragment)"
+                     /ApEinfo_fwdcolor="#EE92FE"
+                     /ApEinfo_revcolor="#EE92FE"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     misc_feature    312..411
+                     /note="pLannotate"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="70.9"
+                     /fragment="True"
+                     /other="misc_feature"
+                     /locus_tag="bom (fragment)"
+                     /label="bom (fragment)"
+                     /ApEinfo_label="bom (fragment)"
+                     /ApEinfo_fwdcolor="#ccff6b"
+                     /ApEinfo_revcolor="#ccff6b"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     rep_origin      complement(597..1185)
+                     /note="pLannotate"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="rep_origin"
+                     /locus_tag="ori"
+                     /label="ori"
+                     /ApEinfo_label="ori"
+                     /ApEinfo_fwdcolor="#2D64FE"
+                     /ApEinfo_revcolor="#2D64FE"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     ncRNA           1157..1261
+                     /note="pLannotate"
+                     /label="RNAI"
+                     /database="Rfam"
+                     /identity="100.0"
+                     /match_length="102.9"
+                     /fragment="False"
+                     /other="ncRNA"
+     promoter        complement(1435..1453)
+                     /note="pLannotate"
+                     /label="AmpR promoter (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="29.7"
+                     /fragment="True"
+                     /other="promoter"
+     gene            complement(1456..2259)
+                     /gene="ura3"
+     CDS             complement(1456..2259)
+                     /gene="ura3"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="orotidine-5'-phosphate decarboxylase"
+                     /protein_id="BAE72675.1"
+                     /translation="MSKATYKERAATHPSPVAAKLFNIMHEKQTNLCASLDVRTTKELL
+                     ELVEALGPKICLLKTHVDILTDFSMEGTVKPLKALSAKYNFLLFEDRKFADIGNTVKLQ
+                     YSAGVYRIAEWADITNAHGVVGPGIVSGLKQAAEEVTKEPRGLLMLAELSCKGSLSTGE
+                     YTKGTVDIAKSDKDFVIGFIAQRDMGGRDEGYDWLIMTPGVGLDDKGDALGQQYRTVDD
+                     VVSTGSDIIIVGRGLFAKGRDAKVEGERYRKAGWEAYLRRCGQQN"
+     CDS             complement(1456..2259)
+                     /note="pLannotate"
+                     /label="URA3"
+                     /database="snapgene"
+                     /identity="99.8"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="CDS"
+     misc            complement(1456..2259)
+                     /label="URA3"
+     promoter        complement(2260..2475)
+                     /note="pLannotate"
+                     /label="URA3 promoter"
+                     /database="snapgene"
+                     /identity="99.5"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="promoter"
+     promoter        complement(2486..2509)
+                     /note="pLannotate"
+                     /label="tet promoter (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="82.8"
+                     /fragment="True"
+                     /other="promoter"
+     misc_feature    complement(2492..2528)
+                     /note="pLannotate"
+                     /label="CEN/ARS (fragment)"
+                     /database="snapgene"
+                     /identity="97.3"
+                     /match_length="3.2"
+                     /fragment="True"
+                     /other="misc_feature"
+     CDS             2500..2925
+                     /note="pLannotate"
+                     /label="RAF1 (fragment)"
+                     /database="swissprot"
+                     /identity="93.0"
+                     /match_length="78.5"
+                     /fragment="True"
+                     /other="CDS"
+     rep_origin      complement(3079..3959)
+                     /note="pLannotate"
+                     /label="2μ ori"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="rep_origin"
+     rep_origin      complement(3970..4011)
+                     /note="pLannotate"
+                     /label="M13 ori (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="8.2"
+                     /fragment="True"
+                     /other="rep_origin"
+     gene            4185..5045
+                     /gene="Amp"
+     CDS             4185..5045
+                     /gene="Amp"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ampicillin resistant protein"
+                     /protein_id="BAE72674.1"
+                     /translation="MSIQHFRVALIPFFAAFCLPVFAHPETLVKVKDAEDQLGARVGYI
+                     ELDLNSGKILESFRPEERFPMMSTFKVLLCDTLLSRIDAGQEQLGRRIHYSQNDLVEYS
+                     PVTEKHLTDGMTVRELCSAAITMSDNTAANLLLTTIGGPKELTAFLHNMGDHVTRLDRW
+                     EPELNEAIPNDESDTTMPVAMPTTLRKLLTGELLTLASRQQLIDWMEADKVAGPLLRSA
+                     LPAGWFIADKSGAGERGSRGIIAALGPDGKRSRIVVIYTTGSQATMDERNRQIAEIGAS
+                     LIKHW"
+     CDS             4185..5045
+                     /note="pLannotate"
+                     /label="AmpR"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="CDS"
+     CDS             4188..4846
+                     /label="AmpR"
+     promoter        complement(4851..4955)
+                     /note="pLannotate"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="promoter"
+                     /locus_tag="AmpR promoter"
+                     /label="AmpR promoter"
+                     /ApEinfo_label="AmpR promoter"
+                     /ApEinfo_fwdcolor="#00891F"
+                     /ApEinfo_revcolor="#00891F"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     ncRNA           4909..5013
+                     /note="pLannotate"
+                     /database="Rfam"
+                     /identity="100.0"
+                     /match_length="102.9"
+                     /fragment="False"
+                     /other="ncRNA"
+                     /locus_tag="RNAI"
+                     /label="RNAI"
+                     /ApEinfo_label="RNAI"
+                     /ApEinfo_fwdcolor="#00D308"
+                     /ApEinfo_revcolor="#00D308"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     CDS             5046..5081
+                     /note="pLannotate"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="18.8"
+                     /fragment="True"
+                     /other="CDS"
+                     /locus_tag="rop (fragment)"
+                     /label="rop (fragment)"
+                     /ApEinfo_label="rop (fragment)"
+                     /ApEinfo_fwdcolor="#A600FA"
+                     /ApEinfo_revcolor="#A600FA"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     misc_feature    5183..5232
+                     /note="pLannotate"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="35.5"
+                     /fragment="True"
+                     /other="misc_feature"
+                     /locus_tag="bom (fragment)(1)"
+                     /label="bom (fragment)(1)"
+                     /ApEinfo_label="bom (fragment)"
+                     /ApEinfo_fwdcolor="#ccff6b"
+                     /ApEinfo_revcolor="#ccff6b"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     terminator      complement(5300..5327)
+                     /note="pLannotate"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="70.0"
+                     /fragment="True"
+                     /other="terminator"
+                     /locus_tag="fd terminator (fragment)"
+                     /label="fd terminator (fragment)"
+                     /ApEinfo_label="fd terminator (fragment)"
+                     /ApEinfo_fwdcolor="#2D64FE"
+                     /ApEinfo_revcolor="#2D64FE"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     misc_feature    5328..5360
+                     /locus_tag="from Ec chromosome"
+                     /label="from Ec chromosome"
+                     /ApEinfo_label="from Ec chromosome"
+                     /ApEinfo_fwdcolor="cyan"
+                     /ApEinfo_revcolor="green"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     rep_origin      complement(3159..4039)
+                     /note="pLannotate"
+                     /label="2μ ori"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="rep_origin"
+     CDS             complement(4185..5045)
+                     /note="pLannotate"
+                     /label="AmpR"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="CDS"
+     rep_origin      complement(792..1380)
+                     /note="pLannotate"
+                     /label="ori"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="rep_origin"
+     promoter        complement(5046..5150)
+                     /note="pLannotate"
+                     /label="AmpR promoter"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="promoter"
+     CDS             complement(1536..2339)
+                     /note="pLannotate"
+                     /label="URA3"
+                     /database="snapgene"
+                     /identity="99.6"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="CDS"
+     promoter        complement(2340..2555)
+                     /note="pLannotate"
+                     /label="URA3 promoter"
+                     /database="snapgene"
+                     /identity="99.5"
+                     /match_length="100.0"
+                     /fragment="False"
+                     /other="promoter"
+     CDS             complement(join(5559..5603,1..426))
+                     /note="pLannotate"
+                     /label="crp (fragment)"
+                     /database="swissprot"
+                     /identity="73.3"
+                     /match_length="74.8"
+                     /fragment="True"
+                     /other="CDS"
+     CDS             2580..3005
+                     /note="pLannotate"
+                     /label="RAF1 (fragment)"
+                     /database="swissprot"
+                     /identity="93.0"
+                     /match_length="78.5"
+                     /fragment="True"
+                     /other="CDS"
+     misc_feature    507..606
+                     /note="pLannotate"
+                     /label="bom (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="70.9"
+                     /fragment="True"
+                     /other="misc_feature"
+     ncRNA           1235..1339
+                     /note="pLannotate"
+                     /label="RNAI"
+                     /database="Rfam"
+                     /identity="100.0"
+                     /match_length="102.9"
+                     /fragment="False"
+                     /other="ncRNA"
+     promoter        complement(2566..2589)
+                     /note="pLannotate"
+                     /label="tet promoter (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="82.8"
+                     /fragment="True"
+                     /other="promoter"
+     terminator      complement(5495..5522)
+                     /note="pLannotate"
+                     /label="fd terminator (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="70.0"
+                     /fragment="True"
+                     /other="terminator"
+     misc_feature    5378..5427
+                     /note="pLannotate"
+                     /label="bom (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="35.5"
+                     /fragment="True"
+                     /other="misc_feature"
+     promoter        complement(487..506)
+                     /note="pLannotate"
+                     /label="T5 promoter (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="44.4"
+                     /fragment="True"
+                     /other="promoter"
+     CDS             5241..5276
+                     /note="pLannotate"
+                     /label="rop (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="18.8"
+                     /fragment="True"
+                     /other="CDS"
+     rep_origin      complement(4050..4091)
+                     /note="pLannotate"
+                     /label="M13 ori (fragment)"
+                     /database="snapgene"
+                     /identity="100.0"
+                     /match_length="8.2"
+                     /fragment="True"
+                     /other="rep_origin"
+     misc_feature    complement(2572..2608)
+                     /note="pLannotate"
+                     /label="CEN/ARS (fragment)"
+                     /database="snapgene"
+                     /identity="97.3"
+                     /match_length="3.2"
+                     /fragment="True"
+                     /other="misc_feature"
+ORIGIN
+        1 gttctgatcc tcgagcatct taagaattcg tcccacggtt tgtctagagc agccgacaat
+       61 ctggccaatt tcctgacggg taattttgat ttgcatgccg tccgggtgag tcatagcgtc
+      121 tggtgacgtc atgcgcatga tatcttcaca ggcggttttc gcacgtaccc atgcgctacg
+      181 ttcctggccc tcttcaaaca ggcccagttc gccaataaaa tcaccctgat tcagatagga
+      241 gaggatcatt tctttaccct cttcgtcttt gatcagcact gccacagagc ctttaacgat
+      301 gtagtacagc gtttccgctt tttcaccctg gtgaataagc gtgctcttgg atgggtactt
+      361 atgaatgtgg caatgagaca agaaccattc gagagtagga tccgtttgag gtttaccaag
+      421 taccataaga tccttaaatt tttattatct agctagatga taatattata tcaagaattg
+      481 tacctgaaag caaataaatt ttttatctgg cttaactatg cggcatcaga gcagattgta
+      541 ctgagagtgc accatatgcg gtgtgaaata ccgcacagat gcgtaaggag aaaataccgc
+      601 atcaggcgct cttccgcttc ctcgctcact gactcgctgc gctcggtcgt tcggctgcgg
+      661 cgagcggtat cagctcactc aaaggcggta atacggttat ccacagaatc aggggataac
+      721 gcaggaaaga acatgtgagc aaaaggccag caaaaggcca ggaaccgtaa aaaggccgcg
+      781 ttgctggcgt ttttccatag gctccgcccc cctgacgagc atcacaaaaa tcgacgctca
+      841 agtcagaggt ggcgaaaccc gacaggacta taaagatacc aggcgtttcc ccctggaagc
+      901 tccctcgtgc gctctcctgt tccgaccctg ccgcttaccg gatacctgtc cgcctttctc
+      961 ccttcgggaa gcgtggcgct ttctcatagc tcacgctgta ggtatctcag ttcggtgtag
+     1021 gtcgttcgct ccaagctggg ctgtgtgcac gaaccccccg ttcagcccga ccgctgcgcc
+     1081 ttatccggta actatcgtct tgagtccaac ccggtaagac acgacttatc gccactggca
+     1141 gcagccactg gtaacaggat tagcagagcg aggtatgtag gcggtgctac agagttcttg
+     1201 aagtggtggc ctaactacgg ctacactaga aggacagtat ttggtatctg cgctctgctg
+     1261 aagccagtta ccttcggaaa aagagttggt agctcttgat ccggcaaaca aaccaccgct
+     1321 ggtagcggtg gtttttttgt ttgcaagcag cagattacgc gcagaaaaaa aggatctcaa
+     1381 gaagatcctt tgatcttttc tacggggtct gacgctcagt ggaacgaaaa ctcacgttaa
+     1441 gggattttgg tcatgagggg taataactga tataattaaa ttgaagctct aatttgtgag
+     1501 tttagtatac atgcatttac ttataataca gttttttagt tttgctggcc gcatcttctc
+     1561 aaatatgctt cccagcctgc ttttctgtaa cgttcaccct ctaccttagc atcccttccc
+     1621 tttgcaaata gtcctcttcc aacaataata atgtcagatc ctgtagagac cacatcatcc
+     1681 acggttctat actgttgacc caatgcgtct cccttgtcat ctaaacccac accgggtgtc
+     1741 ataatcaacc aatcgtaacc ttcatctctt ccacccatgt ctctttgagc aataaagccg
+     1801 ataacaaaat ctttgtcgct cttcgcaatg tcaacagtac ccttagtata ttctccagta
+     1861 gatagggagc ccttgcatga caattctgct aacatcaaaa ggcctctagg ttcctttgtt
+     1921 acttcttctg ccgcctgctt caaaccgcta acaatacctg ggcccaccac accgtgtgca
+     1981 ttcgtaatgt ctgcccattc tgctattctg tatacacccg cagagtactg caatttgact
+     2041 gtattaccaa tgtcagcaaa ttttctgtct tcgaagagta aaaaattgta cttggcggat
+     2101 aatgccttta gcggcttaac tgtgccctcc atggaaaaat cagtcaaaat atccacatgt
+     2161 gtttttagta aacaaatttt gggacctaat gcttcaacta actccagtaa ttccttggtg
+     2221 gtacgaacat ccaatgaagc acacaagttt gtttgctttt cgtgcatgat attaaatagc
+     2281 ttggcagcaa caggactagg atgagtagca gcacgttcct tatatgtagc tttcgacatg
+     2341 atttatcttc gtttcctgca ggtttttgtt ctgtgcagtt gggttaagaa tactgggcaa
+     2401 tttcatgttt cttcaacact acatatgcgt atatatacca atctaagtct gtgctccttc
+     2461 cttcgttctt ccttctgttc ggagattacc gaatcaaaaa aatttcaaag aaaccgaaat
+     2521 caaaaaaaag aataaaaaaa aaatgatgaa ttgaattgaa aagctagctt atcgatgata
+     2581 agctgtcaaa gatgagaatt aattccacgg actatagact atactagata ctccgtctac
+     2641 tgtacgatac acttccgctc aggtccttgt cctttaacga ggccttacca ctcttttgtt
+     2701 actctattga tccagctcag caaaggcagt gtgatctaag attctatctt cgcgatgtag
+     2761 taaaactagc tagaccgaga aagagactag aaatgcaaaa ggcacttcta caatggctgc
+     2821 catcattatt atccgatgtg acgctgcagc ttctcaatga tattcgaata cgctttgagg
+     2881 agatacagcc taatatccga caaactgttt tacagattta cgatcgtact tgttacccat
+     2941 cattgaattt tgaacatccg aacctgggag ttttccctga aacagatagt atatttgaac
+     3001 ctgtataata atatatagtc tagcgcttta cggaagacaa tgtatgtatt tcggttcctg
+     3061 gagaaactat tgcatctatt gcataggtaa tcttgcacgt cgcatccccg gttcattttc
+     3121 tgcgtttcca tcttgcactt caatagcata tctttgttaa cgaagcatct gtgcttcatt
+     3181 ttgtagaaca aaaatgcaac gcgagagcgc taatttttca aacaaagaat ctgagctgca
+     3241 tttttacaga acagaaatgc aacgcgaaag cgctatttta ccaacgaaga atctgtgctt
+     3301 catttttgta aaacaaaaat gcaacgcgac gagagcgcta atttttcaaa caaagaatct
+     3361 gagctgcatt tttacagaac agaaatgcaa cgcgagagcg ctattttacc aacaaagaat
+     3421 ctatacttct tttttgttct acaaaaatgc atcccgagag cgctattttt ctaacaaagc
+     3481 atcttagatt actttttttc tcctttgtgc gctctataat gcagtctctt gataactttt
+     3541 tgcactgtag gtccgttaag gttagaagaa ggctactttg gtgtctattt tctcttccat
+     3601 aaaaaaagcc tgactccact tcccgcgttt actgattact agcgaagctg cgggtgcatt
+     3661 ttttcaagat aaaggcatcc ccgattatat tctataccga tgtggattgc gcatactttg
+     3721 tgaacagaaa gtgatagcgt tgatgattct tcattggtca gaaaattatg aacggtttct
+     3781 tctattttgt ctctatatac tacgtatagg aaatgtttac attttcgtat tgttttcgat
+     3841 tcactctatg aatagttctt actacaattt ttttgtctaa agagtaatac tagagataaa
+     3901 cataaaaaat gtagaggtcg agtttagatg caagttcaag gagcgaaagg tggatgggta
+     3961 ggttatatag ggatatagca cagagatata tagcaaagag atacttttga gcaatgtttg
+     4021 tggaagcggt attcgcaatg ggaagctcca ccccggttga taatcagaaa agccccaaaa
+     4081 acaggaagat tattatcaaa aaggatcttc acctagatcc ttttaaatta aaaatgaagt
+     4141 tttaaatcaa tctaaagtat atatgagtaa acttggtctg acagttacca atgcttaatc
+     4201 agtgaggcac ctatctcagc gatctgtcta tttcgttcat ccatagttgc ctgactcccc
+     4261 gtcgtgtaga taactacgat acgggagcgc ttaccatctg gccccagtgc tgcaatgata
+     4321 ccgcgagacc cacgctcacc ggctccagat ttatcagcaa taaaccagcc agccggaagg
+     4381 gccgagcgca gaagtggtcc tgcaacttta tccgcctcca tccagtctat taattgttgc
+     4441 cgggaagcta gagtaagtag ttcgccagtt aatagtttgc gcaacgttgt tggcattgct
+     4501 acaggcatcg tggtgtcact ctcgtcgttt ggtatggctt cattcagctc cggttcccaa
+     4561 cgatcaaggc gagttacatg atcccccatg ttgtgcaaaa aagcggttag ctccttcggt
+     4621 cctccgatcg ttgtcagaag taagttggcc gcagtgttat cactcatggt tatggcagca
+     4681 ctgcataatt ctcttactgt catgccatcc gtaagatgct tttctgtgac tggtgagtac
+     4741 tcaaccaagt cattctgaga atagtgtatg cggcgaccga gttgctcttg cccggcgtca
+     4801 atacgggata atagtgtatc acatagcaga actttaaaag tgctcatcat tggaaaacgt
+     4861 tcttcggggc gaaaactctc aaggatctta ccgctgttga gatccagttc gatgtaaccc
+     4921 actcgtgcac ccaactgatc ttcagcatct tttactttca ccagcgtttc tgggtgagca
+     4981 aaaacaggaa ggcaaaatgc cgcaaaaaag ggaataaggg cgacacggaa atgttgaata
+     5041 ctcatactct tcctttttca atattattga agcatttatc agggttattg tctcatgagc
+     5101 ggatacatat ttgaatgtat ttagaaaaat aaacaaatag gggttccgcg cacatttccc
+     5161 cgaaaagtgc cacctgctaa gaaaccatta ttatcatgac attaacctat aaaaataggc
+     5221 gtatcacgag gccctttcgt ctcgcgcgtt tcggtgatga cggtgaaaac ctctgacaca
+     5281 tgcagctccc ggagacggtc acagcttgtc tgtaagcgga tgccgggagc agacaagccc
+     5341 gtcagggcgc gtcagcgggt gttggcgggt gtcggggctg gcttaactat gcggcatcag
+     5401 agcagattgt actgagagtg caccatagat cctgaggatc ggggtgataa atcagtctgc
+     5461 gccacatcgg gggaaacaaa atggcgcgag atctaaaaaa aaaggctcca aaaggagcct
+     5521 ttcgcgctac caggtaacgc gccactccga cgggattaac gagtgccgta aacgacgatg
+     5581 gttttaccgt gtgcggagat cag
+//

--- a/tests/test_module_contig2.py
+++ b/tests/test_module_contig2.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+import pytest
+from pydna.dseqrecord import Dseqrecord
+from pydna.assembly import Assembly
+from pydna import contig
+from pydna._pretty import pretty_str
+from pydna.amplify import pcr
+from pydna.parsers import parse_primers
+from pydna.readers import read
+
+
+a = Dseqrecord("acgatgctatactgCCCCCtgtgctgtgctcta", name="one")
+b = Dseqrecord("tgtgctgtgctctaTTTTTtattctggctgtatc", name="two")
+c = Dseqrecord("tattctggctgtatcGGGGGtacgatgctatactg", name="three")
+
+
+@pytest.mark.mpl_image_compare
+def test_contig_linear():
+
+    asm = Assembly((a, b, c), limit=14)
+
+    cont = asm.assemble_linear()[0]
+
+    fig = (
+        "one|14\n" "    \\/\n" "    /\\\n" "    14|two|15\n" "           \\/\n" "           /\\\n" "           15|three"
+    )
+
+    assert fig == cont.figure()
+
+    assert repr(cont) == "Contig(-73)"
+
+    assert cont._repr_html_() == f"<pre>{fig}</pre>"
+
+    assert cont.detailed_figure() == (
+        "acgatgctatactgCCCCCtgtgctgtgctcta\n"
+        "                   TGTGCTGTGCTCTA\n"
+        "                   tgtgctgtgctctaTTTTTtattctggctgtatc\n"
+        "                                      TATTCTGGCTGTATC\n"
+        "                                      tattctggctgtatcGGGGGtacgatgctatactg\n"
+    )
+
+    return cont.figure_mpl()
+
+
+@pytest.mark.mpl_image_compare
+def test_contig_circular():
+
+    asm = Assembly((a, b, c), limit=14)
+
+    cont = asm.assemble_circular()[0]
+
+    assert repr(cont) == "Contig(o59)"
+
+    assert cont.detailed_figure() == (
+        "||||||||||||||\n"
+        "acgatgctatactgCCCCCtgtgctgtgctcta\n"
+        "                   TGTGCTGTGCTCTA\n"
+        "                   tgtgctgtgctctaTTTTTtattctggctgtatc\n"
+        "                                      TATTCTGGCTGTATC\n"
+        "                                      tattctggctgtatcGGGGGtacgatgctatactg\n"
+        "                                                           ACGATGCTATACTG\n"
+    )
+
+    fig = (
+        " -|one|14\n"
+        "|      \\/\n"
+        "|      /\\\n"
+        "|      14|two|15\n"
+        "|             \\/\n"
+        "|             /\\\n"
+        "|             15|three|14\n"
+        "|                      \\/\n"
+        "|                      /\\\n"
+        "|                      14-\n"
+        "|                         |\n"
+        " -------------------------"
+    )
+
+    assert fig == cont.figure()
+
+    return cont.figure_mpl()
+
+    from unittest.mock import MagicMock
+
+    pp = MagicMock()
+
+    cont._repr_pretty_(pp, None)
+
+    pp.text.assert_called_with("Contig(o59)")
+
+    from Bio.Seq import Seq
+
+    from pydna.seqrecord import SeqRecord
+
+    arg = SeqRecord(Seq("aaa"))
+
+    import networkx as nx
+
+    x = contig.Contig.from_SeqRecord(arg, graph=nx.MultiDiGraph())
+
+
+def test_reverse_complement():
+
+    a = Dseqrecord("acgatgctatactgtgCCNCCtgtgctgtgctcta")
+    # 12345678901234
+    b = Dseqrecord("tgtgctgtgctctaTTTTTTTtattctggctgtatc")
+    # 123456789012345
+    c = Dseqrecord("tattctggctgtatcGGGGGtacgatgctatactgtg")
+    a.name = "aaa"  # 1234567890123456
+    b.name = "bbb"
+    c.name = "ccc"
+    asm = Assembly((a, b, c), limit=14)
+    x = asm.assemble_circular()[0]
+    y = x.rc()
+    z = y.rc()
+    assert x.figure() == z.figure()
+    assert x.detailed_figure() == z.detailed_figure()
+
+    xfig = """\
+ -|aaa|14
+|      \\/
+|      /\\
+|      14|bbb|15
+|             \\/
+|             /\\
+|             15|ccc|16
+|                    \\/
+|                    /\\
+|                    16-
+|                       |
+ -----------------------
+     """.rstrip()
+
+    xdfig = pretty_str(
+        """\
+||||||||||||||||
+acgatgctatactgtgCCNCCtgtgctgtgctcta
+                     TGTGCTGTGCTCTA
+                     tgtgctgtgctctaTTTTTTTtattctggctgtatc
+                                          TATTCTGGCTGTATC
+                                          tattctggctgtatcGGGGGtacgatgctatactgtg
+                                                               ACGATGCTATACTGTG
+    """.rstrip()
+        + "\n"
+    )
+
+    assert x.figure() == xfig
+    assert x.detailed_figure() == xdfig
+
+    yfig = """\
+ -|ccc_rc|15
+|         \\/
+|         /\\
+|         15|bbb_rc|14
+|                   \\/
+|                   /\\
+|                   14|aaa_rc|16
+|                             \\/
+|                             /\\
+|                             16-
+|                                |
+ --------------------------------
+     """.rstrip()
+
+    ydfig = (
+        """\
+||||||||||||||||
+cacagtatagcatcgtaCCCCCgatacagccagaata
+                      GATACAGCCAGAATA
+                      gatacagccagaataAAAAAAAtagagcacagcaca
+                                            TAGAGCACAGCACA
+                                            tagagcacagcacaGGNGGcacagtatagcatcgt
+                                                               CACAGTATAGCATCGT
+    """.rstrip()
+        + "\n"
+    )
+
+    assert y.figure() == yfig
+    assert y.detailed_figure() == ydfig
+
+
+def test_linear():
+
+    a = Dseqrecord("acgatgctatactgtgCCNCCtgtgctgtgctcta")
+    # 12345678901234
+    b = Dseqrecord("tgtgctgtgctctaTTTTTTTtattctggctgtatc")
+    # 123456789012345
+    c = Dseqrecord("tattctggctgtatcGGGGGtacgatgctatactgtg")
+    a.name = "aaa"  # 1234567890123456
+    b.name = "bbb"
+    c.name = "ccc"
+    asm = Assembly((a, b, c), limit=14)
+    x = asm.assemble_linear()[0]
+
+    answer = "aaa|14\n    \\/\n    /\\\n    14|bbb|15\n           \\/\n           /\\\n           15|ccc"
+
+    assert x.figure() == answer.strip()
+    answer = "acgatgctatactgtgCCNCCtgtgctgtgctcta\n                     TGTGCTGTGCTCTA\n                     tgtgctgtgctctaTTTTTTTtattctggctgtatc\n                                          TATTCTGGCTGTATC\n                                          tattctggctgtatcGGGGGtacgatgctatactgtg\n"
+    assert x.detailed_figure()
+
+
+@pytest.mark.mpl_image_compare
+def test_mpl1():
+
+    a = Dseqrecord("GCCGATTCTCATCCGGGCCT" "CACTATAGGACCATTCCGTT" "GCCCTGCGCTGCGCTGTATA", name="1")
+
+    b = Dseqrecord("GCCCTGCGCTGCGCTGTATA" "TCCCCAGGAACAGACTTCCT" "GCCGATTCTCATCCGGGCCT", name="2")
+
+    asm = Assembly((a, b), limit=20)
+    cps = asm.assemble_circular()
+    cp = cps[0]
+    return cp.figure_mpl()
+
+
+@pytest.mark.mpl_image_compare
+def test_mpl2():
+
+    x = Dseqrecord("CTAAGATATTCTTACGTGTA" "CACTATAGGACCATTCCGTT" "GCCCTGCGCTGCGCTGTATA", name="x")
+
+    y = Dseqrecord("GCCCTGCGCTGCGCTGTATA" "TCCCCAGGAACAGACTTCCT" "GCCGATTCTCATCCGGGCCT", name="y")
+
+    z = Dseqrecord("GCCGATTCTCATCCGGGCCT" "GGATGCAATGCGATCCTCCG" "CTAAGATATTCTTACGTGTA", name="z")
+
+    asm2 = Assembly((x, y, z), limit=20)
+    cps2 = asm2.assemble_circular()
+    cp2 = cps2[0]
+    return cp2.figure_mpl()
+
+
+@pytest.mark.mpl_image_compare
+def test_mpl3():
+
+    p = {}
+
+    p[1113], p[987], p[1196], p[1195], p[978], p[977], p[984], p[983], p[1804], p[1347] = parse_primers(
+        '''
+
+    >1113_Amp.fw.nw 55-mer
+    GAAAAGCGTTTACCTCGGAACTCTATTGTAGAACCCCTATTTGTTTATTTTTCTA
+
+    >987_Amp.REV 52-merAmp.REV
+    AGAAAGTCTACACCTTACGCTGATTGGATTTGAAGTTTTAAATCAATCTAAA
+
+    >1196_Pbr.FW 49-mer
+    AATCCAATCAGCGTAAGGTGTAGACTTTCTCTGTCAGACCAAGTTTACT
+
+    >1195_Pbr.REV 44-mer
+    GTTGACTACTATTTACGCAGCAGATACGATCTCGTTTCATCGGT
+
+    >978_Crp.FW 46-merCrp.FW
+    AACTGTAAAATCAGGTATCTCGTAGTCCGTGTTCTGATCCTCGAGC
+
+    >977_Crp.REV 47-merCrp.REV
+    TACAATAGAGTTCCGAGGTAAACGCTTTTCGTTCTTGTCTCATTGCC
+
+    >984_Micron.FW 49-merMicron.FW
+    ATCGTATCTGCTGCGTAAATAGTAGTCAACGATCGTACTTGTTACCCAT
+
+    >983_Micron.REV 48-merMicron.REV
+    CAGAGCAGACAGTTCCTTTACGAGATTTTAGATCCAATATCAAAGGAA
+
+    >1804_TRP1fp_pTA 51-merreplaces 1348 & 1680
+    TAAAATCTCGTAAAGGAACTGTCTGCTCTGtataaaaataggcgtatcacg
+
+    >1347_TRP1rp_pTA 51-mer
+    ACGGACTACGAGATACCTGATTTTACAGTTGATCTTTTATGCTTGCTTTTC
+
+    '''
+    )
+
+    lol = [
+        ['pBR322.gb', 1113, 987, 'amp'],
+        ['pBR322.gb', 1196, 1195, 'pBR'],
+        ['pYPKpw.gb', 978, 977, 'Δcrp'],
+        ['YEplac195_snapgene.gb', 984, 983, '2µ'],
+        ['YIplac204_snapgene.gb', 1804, 1347, 'TRP1'],
+    ]
+
+    fragments = []
+
+    for row in lol:
+        template, fp, rp, target = row
+        fp = p[int(fp)]
+        rp = p[int(rp)]
+        template = read(template.strip())
+        fragment = pcr(fp, rp, template)
+        fragment.name = target.strip()
+        fragments.append(fragment)
+
+    asm = Assembly(fragments)
+
+    cps = asm.assemble_circular()
+
+    cp = cps[0]
+
+    return cp.figure_mpl()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv", "-s"])


### PR DESCRIPTION
This adds a method to the contig class called "figure_mpl" which produces a graphic representation of the assembly using matplotlib. 

I would like to pull this code in so that it is here when we decide what the future should be for the contig class (#475).