### PR TITLE
fixed seguid for seqs with U (uracil)

### DIFF
--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1878,7 +1878,7 @@ class Dseq(Seq):
             """docstring."""
             w = f"{self.ovhg * '-'}{self.watson}{'-' * (-self.ovhg + len(self.crick) - len(self.watson))}".upper()
             c = f"{'-' * (self.ovhg + len(self.watson) - len(self.crick))}{self.crick}{-self.ovhg * '-'}".upper()
-            cs = ldseguid(w, c, alphabet="{DNA-extended}")
+            cs = ldseguid(w, c, alphabet="{DNA-extended},AU")
         return cs
 
     def isblunt(self) -> bool:

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -1345,6 +1345,17 @@ def test_checksums():
     )
 
 
+def test_seguid_with_uracil():
+
+    x = Dseq("PEXIaUaOaQFZJ")
+
+    assert x.seguid() == "ldseguid=AA-pG6wsGMu2J-AuWBWlOi3iDc4"
+
+    y = Dseq("QFZJaUaOaPEXI")
+
+    assert y.seguid() == "ldseguid=10e3S-WXX1z0BHqpbYTPeb2MwUY"
+
+
 def test_ovhg():
     # No overhang
     assert Dseq("AAAA").ovhg == 0


### PR DESCRIPTION
basically so that this works:

```
x = Dseq("PEXIaUaOaQFZJ")
assert x.seguid() == "ldseguid=AA-pG6wsGMu2J-AuWBWlOi3iDc4"
y = Dseq("QFZJaUaOaPEXI")
assert y.seguid() == "ldseguid=10e3S-WXX1z0BHqpbYTPeb2MwUY"
```