### PR TITLE
allowing dscode in format Dseqrecord method optionally

### DIFF
--- a/tests/test_module_dseqrecord.py
+++ b/tests/test_module_dseqrecord.py
@@ -456,6 +456,11 @@ def test_format():
         == "LOCUS       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA 6 bp    DNA     linear   UNK 01-JAN-1980"
     )
 
+    assert (
+        Dseqrecord("PEXIGATCQFZJ").format("fasta-2line dscode")
+        == ">id description\nPEXIGATCQFZJ"
+    )
+
 
 def test_write():
 


### PR DESCRIPTION
This modification of the Dseqrecord.format method allows adding "dscode" to the format string to get the dscode in the output. With tests. I need this for the pydnaweb app.

```
>>> print(Dseqrecord("PEXIGATCQFZJ").format("fasta-2line"))
>id description
GATCGATCGATC
>>> print(Dseqrecord("PEXIGATCQFZJ").format("fasta-2line dscode"))
>id description
PEXIGATCQFZJ
```

