### PR TITLE
try fix flaky tests/test_module_contig2.py::test_mpl2 

### DIFF
--- a/.github/workflows/pydna_test_and_coverage_workflow.yml
+++ b/.github/workflows/pydna_test_and_coverage_workflow.yml
@@ -37,6 +37,8 @@ jobs:
       run:
         shell: bash
     runs-on: ${{ matrix.os }}
+    env:
+      MPLBACKEND: Agg
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0


### PR DESCRIPTION
Sometimes, not always, this test fails on windows. This is an attempt to fix that in the workflow file:

```
    env:
      MPLBACKEND: Agg
```


```
0.94s call     tests/test_module_seq.py::test_cai
=========================== short test summary info ===========================
FAILED tests/test_module_contig2.py::test_mpl2 - _tkinter.TclError: Can't find a usable init.tcl in the following directories: 
    {C:\hostedtoolcache\windows\Python\3.10.11\x64\tcl\tcl8.6}

C:/hostedtoolcache/windows/Python/3.10.11/x64/tcl/tcl8.6/init.tcl: couldn't read file "C:/hostedtoolcache/windows/Python/3.10.11/x64/tcl/tcl8.6/init.tcl": No error
couldn't read file "C:/hostedtoolcache/windows/Python/3.10.11/x64/tcl/tcl8.6/init.tcl": No error
    while executing
"source C:/hostedtoolcache/windows/Python/3.10.11/x64/tcl/tcl8.6/init.tcl"
    ("uplevel" body line 1)
    invoked from within
"uplevel #0 [list source $tclfile]"
```