### PR TITLE
New  add methods for Dseq and Dseqrecord

### DIFF
--- a/src/pydna/amplify.py
+++ b/src/pydna/amplify.py
@@ -185,7 +185,9 @@ class Anneal(object):  # ), metaclass=_Memoize):
         Name: 1011bp_PCR_prod
         Description: pcr_product_p1_p2
         Number of features: 2
+        /pydna_parse_sequence_file_format=fasta
         /molecule_type=DNA
+        /topology=linear
         Dseq(-1011)
         taca..gcac
         atgt..cgtg

--- a/src/pydna/amplify.py
+++ b/src/pydna/amplify.py
@@ -390,6 +390,8 @@ class Anneal(object):  # ), metaclass=_Memoize):
                     "description"
                 ) or "pcr_product_{}_{}".format(fp.description, rp.description)
 
+                del prd.position
+
                 amplicon = Amplicon(
                     prd,
                     template=tpl,

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1179,11 +1179,11 @@ class Dseq(Seq):
         >>> "g" + ds # adding a string of left side returns a Dseq
         Dseq(-2)
         ga
-        ct
+         t
         >>> ds + "c" # adding a string of right side returns a Dseq
         Dseq(-2)
         ac
-        tg
+        t
 
 
         Parameters

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -2486,6 +2486,9 @@ class Dseq(Seq):
 
         return self.__class__(result, circular=False)
 
+    def cast_to_ss(self):
+        return type(self)(self._data.translate(dscode_to_watson_tail_table))
+
     def get_cut_parameters(
         self, cut: Union[CutSiteType, None], is_left: bool
     ) -> Tuple[int, int, int]:

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -833,11 +833,14 @@ class Dseqrecord(SeqRecord):
         # Add the two seq objects together, unless other is a string
         # Then add the string and let the Dseq __add__ deal with that.
         other = copy.deepcopy(other)
-        sequence = self.seq + getattr(other, "seq", other)
+        joined = self.seq + getattr(other, "seq", other)
         answer = copy.deepcopy(self)
-        answer.seq = sequence
+        answer.seq = joined
         if hasattr(other, "features"):
-            offset = len(self) + (len(sequence) - len(self) - len(other))
+            # offset is how much other's features needs to be pushed
+            # takes sticky ends into account by measuring lengths of each
+            # element separately and joined.
+            offset = len(self) - (len(self) + len(other) - len(joined))
             for f in other.features:
                 f.location = f.location + offset
             answer.features += other.features

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -1518,3 +1518,8 @@ class Dseqrecord(SeqRecord):
         for x in it:
             result = result + self + x
         return result
+
+    def cast_to_ss(self):
+        answer = copy.deepcopy(self)
+        answer.seq = answer.seq.cast_to_ss()
+        return answer

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -16,7 +16,7 @@ from Bio.Restriction import CommOnly
 from pydna.dseq import Dseq
 from pydna._pretty import pretty_str
 from pydna.utils import flatten, location_boundaries
-
+from pydna.alphabet import dscode_to_watson_tail_table
 from pydna.utils import shift_location
 from pydna.utils import shift_feature
 from pydna.common_sub_strings import common_sub_strings
@@ -805,24 +805,56 @@ class Dseqrecord(SeqRecord):
         )
 
     def __add__(self, other):
-        if hasattr(other, "seq") and hasattr(other.seq, "watson"):
-            other = copy.deepcopy(other)
-            other_five_prime = other.seq.five_prime_end()
-            if other_five_prime[0] == "5'":
-                # add other.seq.ovhg
-                for f in other.features:
-                    f.location = f.location + other.seq.ovhg
-            elif other_five_prime[0] == "3'":
-                # subtract other.seq.ovhg (sign change)
-                for f in other.features:
-                    f.location = f.location + (-other.seq.ovhg)
-
-            answer = Dseqrecord(SeqRecord.__add__(self, other))
-            answer.n = min(self.n, other.n)
+        # handles   self + other
+        if self.circular or getattr(other, "circular", None):
+            # if self is circular or other has an attribute
+            # "circular" that evaluates to True
+            raise TypeError("circular DNA cannot be ligated!")
+        if hasattr(other, "watson"):
+            # if other has the attribute "watson", assume
+            # that other is a Dseq.
+            # Cast other as a Dseqrecord.
+            other = type(self)(other)
+        if hasattr(other, "seq"):
+            if hasattr(other.seq, "watson"):
+                # if other has the attribute "seq" and other.seq has the
+                # attribute "watson", assume that other is a Dseqrecord.
+                pass
+            else:
+                # other has the attribute "seq" but other.seq has no
+                # attribute "watson", assume that other is a SeqRecord.
+                # Cast other.seq as a Dseq
+                other.seq = Dseq(str(other.seq))
         else:
-            answer = Dseqrecord(SeqRecord.__add__(self, Dseqrecord(other)))
-            answer.n = self.n
+            # Assume that other is a string or a Seq object.
+            # Cast other as a string.
+            other = str(other.translate(dscode_to_watson_tail_table))
+
+        # Add the two seq objects together, unless other is a string
+        # Then add the string and let the Dseq __add__ deal with that.
+        other = copy.deepcopy(other)
+        sequence = self.seq + getattr(other, "seq", other)
+        answer = copy.deepcopy(self)
+        answer.seq = sequence
+        if hasattr(other, "features"):
+            offset = len(self) + (len(sequence) - len(self) - len(other))
+            for f in other.features:
+                f.location = f.location + offset
+            answer.features += other.features
         return answer
+
+    def __radd__(self, other):
+        # handles   other + self
+        if isinstance(other, str):
+            offset = len(other)
+            sequence = other.translate(dscode_to_watson_tail_table) + self.seq
+            answer = copy.deepcopy(self)
+            answer.seq = sequence
+            for f in answer.features:
+                f.location = f.location + offset
+            return answer
+        else:
+            return NotImplemented
 
     def __mul__(self, number):
         if not isinstance(number, int):

--- a/tests/test_adding_Dseq_Dseqrecord.py
+++ b/tests/test_adding_Dseq_Dseqrecord.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+from Bio.Seq import Seq
+from Bio.Seq import MutableSeq
+from Bio.SeqRecord import SeqRecord
+from pydna.dseq import Dseq
+from pydna.dseqrecord import Dseqrecord
+
+biopython_Seq = Seq("AT")
+mutable_biopython_Seq = MutableSeq("AT")
+biopython_SeqRecord = SeqRecord(biopython_Seq)
+
+
+def test_adding_Dseq_to_strings_both_sides():
+    """
+    Strings can be added on both sides of a Dseq.
+    The string will be cast as a Dseq with a single watson strand.
+    After that, it will be treated in the same way.
+
+    The joining of Dseqs can be understood as forming one or two phosphodiester
+    bonds with compatible base pairing (or no base pairing in case of single
+    strand sequences).
+
+    ::
+
+        g    tc    gtc
+        |  + ||  = |||
+        c    ag    cag
+
+        g    tc    gtc
+        |  +  |  = |||
+        ca    g    cag
+
+        gt    c    gtc
+        |  +  |  = |||
+        c    ag    cag
+
+    A special case is the joining of two single stranded Dseqs.
+    For single stranded sequences, either a phosphodiester bond is formed
+    or a double stranded sequence depending on the orientation and
+    complementarity of the sequences.
+
+    ::
+
+        gt + ca    gtca
+        ||   ||  = ||||
+
+        gt         gt
+        || + ||  = ||
+             ca    ca
+
+        ||   ||  = ||||
+        gt + ca    gtca
+
+
+    """
+
+    assert "gatc" + Dseq("GT") + "gatc" == Dseq.from_representation(
+        """
+    Dseq(-10)
+    gatcGTgatc
+        CA
+    """
+    )
+    assert Dseq("pexi") + Dseq("GT") + Dseq("pexi") == Dseq.from_representation(
+        """
+    Dseq(-10)
+    gatcGTgatc
+        CA
+    """
+    )
+    assert "gatc" + Dseq("PEXI") + "gatc" == Dseq.from_representation(
+        """
+    Dseq(-12)
+    gatcGATCgatc
+    ||||||||||||
+    """
+    )
+    assert "gatc" + Dseq("QFZJ") == Dseq.from_representation(
+        """
+    Dseq(-4)
+    gatc
+    ctag
+    """
+    )
+    assert Dseq("pexi") + Dseq("QFZJ") == Dseq.from_representation(
+        """
+    Dseq(-4)
+    gatc
+    ctag
+    """
+    )
+    assert Dseq("QFZJ") + "gatc" == Dseq.from_representation(
+        """
+    Dseq(-4)
+    GATC
+    CTAG
+    """
+    )
+    assert Dseq("QFZJ") + Dseq("pexi") == Dseq.from_representation(
+        """
+    Dseq(-4)
+    GATC
+    CTAG
+    """
+    )
+    assert Dseq("QFZJ") + Dseq("qfzj") == Dseq.from_representation(
+        """
+    Dseq(-8)
+    ||||||||
+    CTAGctag
+    """
+    )
+
+    assert Dseq("GP") + Dseq("QT") == Dseq("GGT")
+    assert Dseq("GP") + Dseq("qT") == Dseq("GGT")
+    assert Dseq("Gp") + Dseq("QT") == Dseq("GgT")
+    assert Dseq("Gp") + Dseq("qT") == Dseq("GgT")
+
+    assert Dseq("GP") + Dseq("Q") == Dseq("GG")
+    assert Dseq("GP") + Dseq("q") == Dseq("GG")
+    assert Dseq("Gp") + Dseq("Q") == Dseq("Gg")
+    assert Dseq("Gp") + Dseq("q") == Dseq("Gg")
+
+    with pytest.raises(TypeError) as e:
+        Dseq("GP") + Dseq("G")
+        assert e.match("sticky ends not compatible!")
+    with pytest.raises(TypeError) as e:
+        Dseq("GP") + Dseq("A")
+        assert e.match("sticky ends not compatible!")
+    with pytest.raises(TypeError) as e:
+        Dseq("GP") + Dseq("A")
+        assert e.match("sticky ends not compatible!")
+    with pytest.raises(TypeError) as e:
+        Dseq("GP") + Dseq("C")
+        assert e.match("sticky ends not compatible!")
+
+    assert Dseq("GP") + Dseq("QT") == Dseq("GGT")
+    with pytest.raises(TypeError) as e:
+        Dseq("GP") + Dseq("FT")
+        assert e.match("sticky ends not compatible!")
+    with pytest.raises(TypeError) as e:
+        Dseq("GP") + Dseq("ZT")
+        assert e.match("sticky ends not compatible!")
+    with pytest.raises(TypeError) as e:
+        Dseq("GP") + Dseq("JT")
+        assert e.match("sticky ends not compatible!")
+
+
+def test_adding_strings_to_Dseqrecord_on_both_sides():
+    """ """
+    assert ("aaa" + Dseqrecord("GT") + "aaa").seq == Dseq.from_representation(
+        """
+    Dseq(-8)
+    aaaGTaaa
+       CA
+    """
+    )
+    assert ("gatc" + Dseqrecord("PI") + "gatc").seq == Dseq.from_representation(
+        """
+    Dseq(-10)
+    gatcGCgatc
+    ||||||||||
+    """
+    )
+    assert ("gatc" + Dseqrecord("QFZJ")).seq == Dseq.from_representation(
+        """
+    Dseq(-4)
+    gatc
+    ctag
+    """
+    )
+    assert (Dseqrecord("PEXI") + Dseqrecord("PEXI")).seq == Dseq.from_representation(
+        """
+    Dseq(-8)
+    GATCGATC
+    ||||||||
+    """
+    )
+    assert (Dseqrecord("QFZJ") + Dseqrecord("QFZJ")).seq == Dseq.from_representation(
+        """
+    Dseq(-8)
+    ||||||||
+    CTAGCTAG
+    """
+    )
+
+    with pytest.raises(TypeError) as e:
+        assert (Dseqrecord("QFZJ") + "aaa").seq
+        assert e.match("sticky ends not compatible!")

--- a/tests/test_adding_Dseq_Dseqrecord.py
+++ b/tests/test_adding_Dseq_Dseqrecord.py
@@ -2,14 +2,11 @@
 # -*- coding: utf-8 -*-
 import pytest
 from Bio.Seq import Seq
-from Bio.Seq import MutableSeq
+
+# from Bio.Seq import MutableSeq
 from Bio.SeqRecord import SeqRecord
 from pydna.dseq import Dseq
 from pydna.dseqrecord import Dseqrecord
-
-biopython_Seq = Seq("AT")
-mutable_biopython_Seq = MutableSeq("AT")
-biopython_SeqRecord = SeqRecord(biopython_Seq)
 
 
 def test_adding_Dseq_to_strings_both_sides():
@@ -189,3 +186,16 @@ def test_adding_strings_to_Dseqrecord_on_both_sides():
     with pytest.raises(TypeError) as e:
         assert (Dseqrecord("QFZJ") + "aaa").seq
         assert e.match("sticky ends not compatible!")
+
+
+def test_adding_to_Dseqrecord_on_both_sides():
+    # biopython_Seq = Seq("AT")
+    # mutable_biopython_Seq = MutableSeq("AT")
+    # biopython_SeqRecord = SeqRecord(biopython_Seq)
+    assert (Dseqrecord("GT") + SeqRecord(Seq("AT"))).seq == Dseqrecord("GTAT").seq
+    assert (SeqRecord(Seq("AT")) + Dseqrecord("GT")).seq == SeqRecord(
+        seq=Seq("ATGT")
+    ).seq
+    with pytest.raises(TypeError) as e:
+        Seq("AT") + Dseqrecord("GT")
+        assert e.match("unsupported operand")

--- a/tests/test_module_assembly2.py
+++ b/tests/test_module_assembly2.py
@@ -1392,8 +1392,8 @@ def test_ends_from_cutsite():
     cut = a.get_cutsites([BsaI])[0]
     a1, a2 = a.cut([BsaI])
     assert assembly.ends_from_cutsite(cut, a) == (
-        a1.three_prime_end(),
-        a2.five_prime_end(),
+        (a1.three_prime_end()[0], a1.three_prime_end()[1].lower()),
+        (a2.five_prime_end()[0], a2.five_prime_end()[1].lower()),
     )
 
     a = Dseq("ACcTGatacACTGGATactA", circular=False)
@@ -1401,8 +1401,8 @@ def test_ends_from_cutsite():
     cut = a.get_cutsites([BsrI])[0]
     a1, a2 = a.cut([BsrI])
     assert assembly.ends_from_cutsite(cut, a) == (
-        a1.three_prime_end(),
-        a2.five_prime_end(),
+        (a1.three_prime_end()[0], a1.three_prime_end()[1].lower()),
+        (a2.five_prime_end()[0], a2.five_prime_end()[1].lower()),
     )
 
     with pytest.raises(ValueError):

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -468,11 +468,11 @@ def test_dseq_circular_linear():
     assert obj[2:1]._data == b"ga"
 
     obj = Dseq("G", "", 0)
-    assert obj.five_prime_end() == ("single", "g")
-    assert obj.three_prime_end() == ("single", "g")
+    assert obj.five_prime_end() == ("single", "G")
+    assert obj.three_prime_end() == ("single", "G")
     obj = Dseq("", "C", 0)
-    assert obj.five_prime_end() == ("single", "c")
-    assert obj.three_prime_end() == ("single", "c")
+    assert obj.five_prime_end() == ("single", "C")
+    assert obj.three_prime_end() == ("single", "C")
 
     obj = Dseq("ccGGATCC", "aaggatcc", -2)
     # assert obj._data == b"ccGGATCCtt"


### PR DESCRIPTION
This is a solution to uniform how adding works with strings, Dseqs and Dseqrecords.
This is important for dropping the Primer class in the near future. Part of #475
todo:
- [ ] better docstrings

