### PR TITLE
Refactor parsers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,9 @@ minversion = "6.0.2"
 python_files = "test_*.py"
 testpaths = ["tests", "src/pydna"]
 norecursedirs = ["*"]
+markers = [
+    "mpl_image_compare",
+]
 
 [tool.black]
 include = '\.pyi?$'

--- a/src/pydna/genbankfixer.py
+++ b/src/pydna/genbankfixer.py
@@ -29,60 +29,60 @@ import pyparsing as pp
 
 GoodLocus = (
     pp.Literal("LOCUS")
-    + pp.Word(pp.alphas + pp.nums + "-_()." + "\\").setResultsName("name")
-    + pp.Word(pp.nums).setResultsName("size")
+    + pp.Word(pp.alphas + pp.nums + "-_()." + "\\").set_results_name("name")
+    + pp.Word(pp.nums).set_results_name("size")
     + pp.Suppress(pp.CaselessLiteral("bp"))
-    + pp.Word(pp.alphas + "-").setResultsName("seqtype")
-    + (pp.CaselessLiteral("linear") | pp.CaselessLiteral("circular")).setResultsName(
+    + pp.Word(pp.alphas + "-").set_results_name("seqtype")
+    + (pp.CaselessLiteral("linear") | pp.CaselessLiteral("circular")).set_results_name(
         "topology"
     )
-    + pp.Optional(pp.Word(pp.alphas), default="   ").setResultsName("divcode")
-    + pp.Regex(r"(\d{2})-(\S{3})-(\d{4})").setResultsName("date")
+    + pp.Optional(pp.Word(pp.alphas), default="   ").set_results_name("divcode")
+    + pp.Regex(r"(\d{2})-(\S{3})-(\d{4})").set_results_name("date")
 )
 
 # Older versions of ApE don't include a LOCUS name! Need separate def for this case:
 BrokenLocus1 = (
-    pp.Literal("LOCUS").setResultsName("name")
-    + pp.Word(pp.nums).setResultsName("size")
+    pp.Literal("LOCUS").set_results_name("name")
+    + pp.Word(pp.nums).set_results_name("size")
     + pp.Suppress(pp.CaselessLiteral("bp"))
-    + pp.Word(pp.alphas + "-").setResultsName("seqtype")
-    + (pp.CaselessLiteral("linear") | pp.CaselessLiteral("circular")).setResultsName(
+    + pp.Word(pp.alphas + "-").set_results_name("seqtype")
+    + (pp.CaselessLiteral("linear") | pp.CaselessLiteral("circular")).set_results_name(
         "topology"
     )
-    + pp.Optional(pp.Word(pp.alphas), default="   ").setResultsName("divcode")
-    + pp.Regex(r"(\d{2})-(\S{3})-(\d{4})").setResultsName("date")
+    + pp.Optional(pp.Word(pp.alphas), default="   ").set_results_name("divcode")
+    + pp.Regex(r"(\d{2})-(\S{3})-(\d{4})").set_results_name("date")
 )
 
 # LOCUS       YEplac181	5741 bp 	DNA	SYN
 BrokenLocus2 = (
     pp.Literal("LOCUS")
-    + pp.Word(pp.alphas + pp.nums + "-_()." + "\\").setResultsName("name")
-    + pp.Word(pp.nums).setResultsName("size")
+    + pp.Word(pp.alphas + pp.nums + "-_()." + "\\").set_results_name("name")
+    + pp.Word(pp.nums).set_results_name("size")
     + pp.Suppress(pp.CaselessLiteral("bp"))
-    + pp.Word(pp.alphas + "-").setResultsName("seqtype")
+    + pp.Word(pp.alphas + "-").set_results_name("seqtype")
     + pp.Optional(
         pp.CaselessLiteral("linear") | pp.CaselessLiteral("circular"),
         default="linear",
-    ).setResultsName("topology")
-    + pp.Optional(pp.Word(pp.alphas), default="   ").setResultsName("divcode")
-    + pp.Regex(r"(\d{2})-(\S{3})-(\d{4})").setResultsName("date")
+    ).set_results_name("topology")
+    + pp.Optional(pp.Word(pp.alphas), default="   ").set_results_name("divcode")
+    + pp.Regex(r"(\d{2})-(\S{3})-(\d{4})").set_results_name("date")
 )
 
 BrokenLocus3 = (
     pp.Literal("LOCUS")
-    + pp.Word(pp.alphas + pp.nums + "-_()." + "\\").setResultsName("name")
-    + pp.Word(pp.nums).setResultsName("size")
+    + pp.Word(pp.alphas + pp.nums + "-_()." + "\\").set_results_name("name")
+    + pp.Word(pp.nums).set_results_name("size")
     + pp.Suppress(pp.CaselessLiteral("bp"))
-    + pp.Word(pp.alphas + "-").setResultsName("seqtype")
+    + pp.Word(pp.alphas + "-").set_results_name("seqtype")
     + pp.Optional(
         pp.CaselessLiteral("linear") | pp.CaselessLiteral("circular"),
         default="linear",
-    ).setResultsName("topology")
-    + pp.Word(pp.alphas).setResultsName("divcode")
+    ).set_results_name("topology")
+    + pp.Word(pp.alphas).set_results_name("divcode")
     + pp.Optional(
-        pp.Regex(r"(\d{2})-(\S{3})-(\d{4})").setResultsName("date"),
+        pp.Regex(r"(\d{2})-(\S{3})-(\d{4})").set_results_name("date"),
         default="19-MAR-1970",
-    ).setResultsName("date")
+    ).set_results_name("date")
 )
 
 LocusEntry = GoodLocus | BrokenLocus1 | BrokenLocus2 | BrokenLocus3
@@ -102,7 +102,7 @@ SpacedLine = pp.White(min=1) + pp.CharsNotIn("\n") + pp.LineEnd()
 # HeaderLine = CapWord + CharsNotIn("\n") + LineEnd()
 GenericEntry = pp.Group(
     CapWord + pp.Combine(pp.CharsNotIn("\n") + pp.LineEnd() + pp.ZeroOrMore(SpacedLine))
-).setResultsName("generics", listAllMatches=True)
+).set_results_name("generics", list_all_matches=True)
 
 
 # ===============================================================================
@@ -139,10 +139,10 @@ RPAREN = pp.Suppress(")")
 SEP = pp.Suppress(pp.Literal(".."))
 
 # recognize numbers w. < & > uncertainty specs, then strip the <> chars to make it fixed
-gbIndex = pp.Word(pp.nums + "<>").setParseAction(
+gbIndex = pp.Word(pp.nums + "<>").set_parse_action(
     lambda s, l_, t: int(t[0].replace("<", "").replace(">", ""))
 )
-SimpleSlice = pp.Group(gbIndex + SEP + gbIndex) | pp.Group(gbIndex).setParseAction(
+SimpleSlice = pp.Group(gbIndex + SEP + gbIndex) | pp.Group(gbIndex).set_parse_action(
     lambda s, l_, t: [[t[0][0], t[0][0]]]
 )
 
@@ -152,7 +152,7 @@ complexSlice = pp.Forward()
     complexSlice
     << (pp.Literal("complement") | pp.Literal("join"))
     + LPAREN
-    + (pp.delimitedList(complexSlice) | pp.delimitedList(SimpleSlice))
+    + (pp.DelimitedList(complexSlice) | pp.DelimitedList(SimpleSlice))
     + RPAREN
 )
 featLocation = pp.Group(SimpleSlice | complexSlice)
@@ -176,7 +176,7 @@ def parseGBLoc(s, l_, t):
     return [["location", locationlist], ["strand", strand]]
 
 
-featLocation.setParseAction(parseGBLoc)
+featLocation.set_parse_action(parseGBLoc)
 
 # ==== Genbank Feature Key-Value Pairs
 
@@ -195,7 +195,7 @@ QuoteFeaturekeyval = pp.Group(
     pp.Suppress("/")
     + pp.Word(pp.alphas + pp.nums + "_-")
     + pp.Suppress("=")
-    + pp.QuotedString('"', multiline=True).setParseAction(strip_multiline)
+    + pp.QuotedString('"', multiline=True).set_parse_action(strip_multiline)
 )
 
 # UnQuoted KeyVal: /key=value  (I'm assuming it doesn't do multilines this way? wrong! ApE does store long labels this way! sigh.)
@@ -218,21 +218,21 @@ NumFeaturekeyval = pp.Group(
     pp.Suppress("/")
     + pp.Word(pp.alphas + pp.nums + "_-")
     + pp.Suppress("=")
-    + (pp.Suppress('"') + pp.Word(pp.nums).setParseAction(toInt) + pp.Suppress('"'))
-    | (pp.Word(pp.nums).setParseAction(toInt))
+    + (pp.Suppress('"') + pp.Word(pp.nums).set_parse_action(toInt) + pp.Suppress('"'))
+    | (pp.Word(pp.nums).set_parse_action(toInt))
 )
 
 # Key Only KeyVal: /pseudo
 # post-parse convert it into a pair to resemble the structure of the first three cases i.e. [pseudo, True]
 FlagFeaturekeyval = pp.Group(
     pp.Suppress("/") + pp.Word(pp.alphas + pp.nums + "_-")
-).setParseAction(lambda s, l_, t: [[t[0][0], True]])
+).set_parse_action(lambda s, l_, t: [[t[0][0], True]])
 
 Feature = pp.Group(
-    pp.Word(pp.alphas + pp.nums + "_-").setParseAction(
+    pp.Word(pp.alphas + pp.nums + "_-").set_parse_action(
         lambda s, l_, t: [["type", t[0]]]
     )
-    + featLocation.setResultsName("location")
+    + featLocation.set_results_name("location")
     + pp.OneOrMore(
         NumFeaturekeyval | QuoteFeaturekeyval | NoQuoteFeaturekeyval | FlagFeaturekeyval
     )
@@ -241,7 +241,7 @@ Feature = pp.Group(
 FeaturesEntry = (
     pp.Literal("FEATURES")
     + pp.Literal("Location/Qualifiers")
-    + pp.Group(pp.OneOrMore(Feature)).setResultsName("features")
+    + pp.Group(pp.OneOrMore(Feature)).set_results_name("features")
 )
 
 # ===============================================================================
@@ -253,10 +253,10 @@ Sequence = pp.OneOrMore(
     pp.Suppress(pp.Word(pp.nums)) + pp.OneOrMore(pp.Word("ACGTacgtNn"))
 )
 
-# Group(  ) hides the setResultsName names def'd inside, such that one needs to first access this group and then access the dict of contents inside
-SequenceEntry = pp.Suppress(pp.Literal("ORIGIN")) + Sequence.setParseAction(
+# Group(  ) hides the set_results_name names def'd inside, such that one needs to first access this group and then access the dict of contents inside
+SequenceEntry = pp.Suppress(pp.Literal("ORIGIN")) + Sequence.set_parse_action(
     lambda s, l_, t: "".join(t)
-).setResultsName("sequence")
+).set_results_name("sequence")
 
 
 # ===============================================================================
@@ -299,7 +299,7 @@ def concat_dict(dlist):
 
 
 def toJSON(gbkstring):
-    parsed = multipleGB.parseString(gbkstring)
+    parsed = multipleGB.parse_string(gbkstring)
 
     jseqlist = []
 

--- a/src/pydna/parsers.py
+++ b/src/pydna/parsers.py
@@ -10,8 +10,10 @@
 import re
 import io
 import textwrap
-
+import os
 from Bio import SeqIO
+from Bio.SeqIO.InsdcIO import GenBankScanner, GenBankIterator
+import warnings
 
 from pydna.dseqrecord import Dseqrecord
 from Bio.SeqRecord import SeqRecord
@@ -68,6 +70,76 @@ def extract_from_text(text):
     return tuple(mo.group(0) for mo in mos), tuple(gaps)
 
 
+class CustomGenBankScanner(GenBankScanner):
+    """
+    A custom GenBank scanner that parses the LOCUS line and extracts the name, size, molecule_type, topology and date
+    from malformed GenBank files.
+
+    For example, the following line:
+
+    ```
+        LOCUS       pKM265       4536 bp    DNA   circular  SYN        21-JUN-2013
+    ```
+    """
+
+    def _feed_first_line(self, consumer, line):
+        # A regex for
+        m = re.match(
+            r"(?i)LOCUS\s+(?P<name>\S+)\s+(?P<size>\d+ bp)\s+(?P<molecule_type>\S+)(?:\s+(?P<topology>circular|linear))?(?:\s+.+\s+)?(?P<date>\d+-\w+-\d+)?",
+            line,
+        )
+        if m is None:
+            raise ValueError("LOCUS line cannot be parsed")
+        name, size, molecule_type, topology, date = m.groups()
+
+        consumer.locus(name)
+        consumer.size(size[:-3])
+        consumer.molecule_type(molecule_type)
+        consumer.topology(topology.lower() if topology is not None else None)
+        consumer.date(date)
+
+
+class CustomGenBankIterator(GenBankIterator):
+
+    def __init__(self, source):
+        super(GenBankIterator, self).__init__(source, fmt="GenBank")
+        self.records = CustomGenBankScanner(debug=0).parse_records(self.stream)
+
+
+def parse_genbank(handle: io.StringIO) -> SeqRecord:
+    """
+    Equivalent to SeqIO.read(handle, "genbank") but with more permissive parsing for the LOCUS line. It also
+    removes BASE_COUNT lines that can be misplaced and anyway are not stored in the SeqRecord.annotations.
+    """
+
+    filtered_lines = list()
+    for line in handle:
+        if not line.lstrip().startswith("BASE COUNT"):
+            filtered_lines.append(line)
+    filtered_handle = io.StringIO("".join(filtered_lines))
+
+    try:
+        # This may raise a ValueError such as "LOCUS line does not contain space at position X"
+        # then use the more permissive CustomGenBankIterator
+        parsed = SeqIO.read(filtered_handle, "genbank")
+
+        # Sometimes the line is enough to parse the record, but not enough to parse the topology,
+        # then raise an error starting with "LOCUS line does not contain" to trigger the
+        # more permissive CustomGenBankIterator
+        if "topology" not in parsed.annotations.keys():
+            raise ValueError("LOCUS line does not contain topology")
+        return parsed
+    except ValueError as e:
+        if "LOCUS line does not contain" not in str(e):
+            raise e
+        filtered_handle.seek(0)
+        warnings.warn(
+            "LOCUS line is wrongly formatted, we used a more permissive parser.",
+            stacklevel=2,
+        )
+        return next(CustomGenBankIterator(filtered_handle))
+
+
 def embl_gb_fasta(text):
     """Parse embl, genbank or fasta format from text.
 
@@ -79,11 +151,9 @@ def embl_gb_fasta(text):
     """
     chunks, gaps = extract_from_text(text)
     result_list = []
-    # topology = "linear"
 
     for chunk in chunks:
         handle = io.StringIO(chunk)
-        # circular = False
         first_line = chunk.splitlines()[0].lower().split()
         try:
             parsed = SeqIO.read(handle, "embl")
@@ -91,7 +161,7 @@ def embl_gb_fasta(text):
         except ValueError:
             handle.seek(0)
             try:
-                parsed = SeqIO.read(handle, "genbank")
+                parsed = parse_genbank(handle)
                 parsed.annotations["pydna_parse_sequence_file_format"] = "genbank"
             except ValueError:
                 handle.seek(0)
@@ -126,7 +196,7 @@ def embl_gb_fasta(text):
     return tuple(result_list)
 
 
-def parse(data, ds=True) -> list[Dseqrecord | SeqRecord]:
+def parse(data, ds=True, is_path=None) -> list[Dseqrecord | SeqRecord]:
     """Return *all* DNA sequences found in data.
 
     If no sequences are found, an empty list is returned. This is a greedy
@@ -155,6 +225,10 @@ def parse(data, ds=True) -> list[Dseqrecord | SeqRecord]:
         If False single stranded :class:`Bio.SeqRecord` [#]_ objects are
         returned.
 
+    is_path : bool, optional
+        If True, the data is treated as a path to a file. If False, the data is treated as a string (e.g. FASTA file content).
+        If None, the both are tried.
+
     Returns
     -------
     list
@@ -178,37 +252,33 @@ def parse(data, ds=True) -> list[Dseqrecord | SeqRecord]:
     sequences = []
 
     for item in data:
-        try:
-            # item is a path to a utf-8 encoded text file?
-            with open(item, "r", encoding="utf-8") as f:
-                raw = f.read()
-        except IOError:
-            # item was not a path, add sequences parsed from item
-            raw = item
-            path = None
-        else:
-            # item was a readable text file, seqences are parsed from the file
+        if is_path is None:
+            path = item if os.path.isfile(item) else None
+        elif is_path:
             path = item
-        finally:
-            newsequences = embl_gb_fasta(raw)
-            for s in newsequences:
-                if ds and path:
-                    from pydna.opencloning_models import UploadedFileSource
+        else:
+            path = None
 
-                    result = Dseqrecord.from_SeqRecord(s)
-                    result.source = UploadedFileSource(
-                        file_name=str(path),  # we use str to handle PosixPath
-                        sequence_file_format=s.annotations[
-                            "pydna_parse_sequence_file_format"
-                        ],
-                        index_in_file=0,
-                    )
-                    sequences.append(result)
-                    # sequences.append(_GenbankFile.from_SeqRecord(s, path=path))
-                elif ds:
-                    sequences.append(Dseqrecord.from_SeqRecord(s))
-                else:
-                    sequences.append(s)
+        raw = item if not path else open(path, "r", encoding="utf-8").read()
+
+        newsequences = embl_gb_fasta(raw)
+        for s in newsequences:
+            if ds and path:
+                from pydna.opencloning_models import UploadedFileSource
+
+                result = Dseqrecord.from_SeqRecord(s)
+                result.source = UploadedFileSource(
+                    file_name=str(path),  # we use str to handle PosixPath
+                    sequence_file_format=s.annotations[
+                        "pydna_parse_sequence_file_format"
+                    ],
+                    index_in_file=0,
+                )
+                sequences.append(result)
+            elif ds:
+                sequences.append(Dseqrecord.from_SeqRecord(s))
+            else:
+                sequences.append(s)
     return sequences
 
 

--- a/src/pydna/parsers.py
+++ b/src/pydna/parsers.py
@@ -88,7 +88,7 @@ class CustomGenBankScanner(GenBankScanner):
             r"(?i)LOCUS\s+(?P<name>\S+)\s+(?P<size>\d+ bp)\s+(?P<molecule_type>\S+)(?:\s+(?P<topology>circular|linear))?(?:\s+.+\s+)?(?P<date>\d+-\w+-\d+)?",
             line,
         )
-        if m is None:
+        if m is None:  # pragma: no cover - I don't think this can happen, but JIC
             raise ValueError("LOCUS line cannot be parsed")
         name, size, molecule_type, topology, date = m.groups()
 

--- a/src/pydna/parsers.py
+++ b/src/pydna/parsers.py
@@ -227,7 +227,7 @@ def parse(data, ds=True, is_path=None) -> list[Dseqrecord | SeqRecord]:
 
     is_path : bool, optional
         If True, the data is treated as a path to a file. If False, the data is treated as a string (e.g. FASTA file content).
-        If None, the both are tried.
+        If None, both are tried.
 
     Returns
     -------

--- a/src/pydna/parsers.py
+++ b/src/pydna/parsers.py
@@ -259,7 +259,11 @@ def parse(data, ds=True, is_path=None) -> list[Dseqrecord | SeqRecord]:
         else:
             path = None
 
-        raw = item if not path else open(path, "r", encoding="utf-8").read()
+        if path:
+            with open(path, "r", encoding="utf-8") as f:
+                raw = f.read()
+        else:
+            raw = item
 
         newsequences = embl_gb_fasta(raw)
         for s in newsequences:

--- a/src/pydna/readers.py
+++ b/src/pydna/readers.py
@@ -10,7 +10,7 @@ from pydna.parsers import parse
 from pydna.primer import Primer
 
 
-def read(data, ds=True):
+def read(data, ds=True, is_path=None):
     """This function is similar the :func:`parse` function but expects one and only
     one sequence or and exception is thrown.
 
@@ -21,6 +21,9 @@ def read(data, ds=True):
     ds : bool
         Double stranded or single stranded DNA, if True return
         Dseqrecord objects, else Bio.SeqRecord objects.
+    is_path : bool, optional
+        If True, the data is treated as a path to a file. If False, the data is treated as a string (e.g. FASTA file content).
+        If None, the both are tried.
 
     Returns
     -------
@@ -39,7 +42,7 @@ def read(data, ds=True):
     """
 
     try:
-        (result,) = parse(data, ds)
+        (result,) = parse(data, ds, is_path)
     except ValueError as err:
         msg = str(err)
 

--- a/src/pydna/readers.py
+++ b/src/pydna/readers.py
@@ -23,7 +23,7 @@ def read(data, ds=True, is_path=None):
         Dseqrecord objects, else Bio.SeqRecord objects.
     is_path : bool, optional
         If True, the data is treated as a path to a file. If False, the data is treated as a string (e.g. FASTA file content).
-        If None, the both are tried.
+        If None, both are tried.
 
     Returns
     -------

--- a/tests/broken_genbank_files/P2RP3.ape
+++ b/tests/broken_genbank_files/P2RP3.ape
@@ -1,0 +1,107 @@
+LOCUS       P2RP3                   4773 bp    DNA        circular     26-NOV-2024
+DEFINITION  .
+ACCESSION
+VERSION
+SOURCE      .
+  ORGANISM  .
+COMMENT
+COMMENT     ApEinfo:methylated:1
+FEATURES             Location/Qualifiers
+     misc_feature    591..822
+                     /locus_tag="attP2R"
+                     /label="attP2R"
+                     /ApEinfo_label="attP2R"
+                     /ApEinfo_fwdcolor="cyan"
+                     /ApEinfo_revcolor="cyan"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     misc_feature    2746..2977
+                     /locus_tag="attP3"
+                     /label="attP3"
+                     /ApEinfo_label="attP3"
+                     /ApEinfo_fwdcolor="cyan"
+                     /ApEinfo_revcolor="cyan"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+ORIGIN
+        1 ctttcctgcg ttatcccctg attctgtgga taaccgtatt accgcctttg agtgagctga
+       61 taccgctcgc cgcagccgaa cgaccgagcg cagcgagtca gtgagcgagg aagcggaaga
+      121 gcgcccaata cgcaaaccgc ctctccccgc gcgttggccg attcattaat gcagctggca
+      181 cgacaggttt cccgactgga aagcgggcag tgagcgcaac gcaattaata cgcgtaccgc
+      241 tagccaggaa gagtttgtag aaacgcaaaa aggccatccg tcaggatggc cttctgctta
+      301 gtttgatgcc tggcagttta tggcgggcgt cctgcccgcc accctccggg ccgttgcttc
+      361 acaacgttca aatccgctcc cggcggattt gtcctactca ggagagcgtt caccgacaaa
+      421 caacagataa aacgaaaggc ccagtcttcc gactgagcct ttcgttttat ttgatgcctg
+      481 gcagttccct actctcgcgt taacgctagc atggatgttt tcccagtcac gacgttgtaa
+      541 aacgacggcc agtcttaagc tcgggccctg cagctctaga gctcgaattc tacaggtcac
+      601 taataccatc taagtagttg attcatagtg actgcatatg ttgtgtttta cagtattatg
+      661 tagtctgttt tttatgcaaa atctaattta atatattgat atttatatca ttttacgttt
+      721 ctcgttcaac tttcttgtac aaagttggca ttataaaaaa gcattgctta tcaatttgtt
+      781 gcaacgaaca ggtcactatc agtcaaaata aaatcattat ttggagctct agagcgtcga
+      841 ctaagttggc agcatcaccc gacgcacttt gcgccgaata aatacctgtg acggaagatc
+      901 acttcgcaga ataaataaat cctggtgtcc ctgttgatac cgggaagccc tgggccaact
+      961 tttggcgaaa atgagacgtt gatcggcacg taagaggttc caactttcac cataatgaaa
+     1021 taagatcact accgggcgta ttttttgagt tatcgagatt ttcaggagct aaggaagcta
+     1081 aaatggagaa aaaaatcact ggatatacca ccgttgatat atcccaatgg catcgtaaag
+     1141 aacattttga ggcatttcag tcagttgctc aatgtaccta taaccagacc gttcagctgg
+     1201 atattacggc ctttttaaag accgtaaaga aaaataagca caagttttat ccggccttta
+     1261 ttcacattct tgcccgcctg atgaatgctc atccggaatt ccgtatggca atgaaagacg
+     1321 gtgagctggt gatatgggat agtgttcacc cttgttacac cgttttccat gagcaaactg
+     1381 aaacgttttc atcgctctgg agtgaatacc acgacgattt ccggcagttt ctacacatat
+     1441 attcgcaaga tgtggcgtgt tacggtgaaa acctggccta tttccctaaa gggtttattg
+     1501 agaatatgtt tttcgtctca gccaatccct gggtgagttt caccagtttt gatttaaacg
+     1561 tggccaatat ggacaacttc ttcgcccccg ttttcaccat gggcaaatat tatacgcaag
+     1621 gcgacaaggt gctgatgccg ctggcgattc aggttcatca tgccgtctgt gatggcttcc
+     1681 atgtcggcag aatgcttaat gaattacaac agtactgcga tgagtggcag ggcggggcgt
+     1741 aatcgcgtgg atccggctta ctaaaagcca gataacagta tgcgtatttg cgcgctgatt
+     1801 tttgcggtat aagaatatat actgatatgt atacccgaag tatgtcaaaa agaggtgtgc
+     1861 tatgaagcag cgtattacag tgacagttga cagcgacagc tatcagttgc tcaaggcata
+     1921 tatgatgtca atatctccgg tctggtaagc acaaccatgc agaatgaagc ccgtcgtctg
+     1981 cgtgccgaac gctggaaagc ggaaaatcag gaagggatgg ctgaggtcgc ccggtttatt
+     2041 gaaatgaacg gctcttttgc tgacgagaac agggactggt gaaatgcagt ttaaggttta
+     2101 cacctataaa agagagagcc gttatcgtct gtttgtggat gtacagagtg atattattga
+     2161 cacgcccggg cgacggatgg tgatccccct ggccagtgca cgtctgctgt cagataaagt
+     2221 ctcccgtgaa ctttacccgg tggtgcatat cggggatgaa agctggcgca tgatgaccac
+     2281 cgatatggcc agtgtgccgg tctccgttat cggggaagaa gtggctgatc tcagccaccg
+     2341 cgaaaatgac atcaaaaacg ccattaacct gatgttctgg ggaatataaa tgtcaggctc
+     2401 ccttatacac agccagtctg caggtcgata cagtagaaat tacagaaact ttatcacgtt
+     2461 tagtaagtat agaggctgaa aatccagatg aagccgaacg acttgtaaga gaaaagtata
+     2521 agagttgtga aattgttctt gatgcagatg attttcagga ctatgacact agcgtatatg
+     2581 aataggtaga tgtttttatt ttgtcacaca aaaaagaggc tcgcacctct ttttcttatt
+     2641 tctttttatg atttaatacg gcattgagga caatagcgag taggctggat acgacgattc
+     2701 cgtttgagaa gaacatttgg aaggctgtcg gtcgagctcg aattctacag gtcactaata
+     2761 ccatctaagt agttgattca tagtgactgc atatgttgtg ttttacagta ttatgtagtc
+     2821 tgttttttat gcaaaatcta atttaatata ttgatattta tatcatttta cgtttctcgt
+     2881 tcaactttat tatacaaagt tggcattata aaaaagcatt gcttatcaat ttgttgcaac
+     2941 gaacaggtca ctatcagtca aaataaaatc attatttgga gctccatggt agcgttaacg
+     3001 cggccgcgat atcccctata gtgagtcgta ttacatggtc atagctgttt cctggcagct
+     3061 ctggcccgtg tctcaaaatc tctgatgtta cattgcacaa gataaaaata tatcatcatg
+     3121 aacaataaaa ctgtctgctt acataaacag taatacaagg ggtgttatga gccatattca
+     3181 acgggaaacg tcgaggccgc gattaaattc caacatggat gctgatttat atgggtataa
+     3241 atgggctcgc gataatgtcg ggcaatcagg tgcgacaatc tatcgcttgt atgggaagcc
+     3301 cgatgcgcca gagttgtttc tgaaacatgg caaaggtagc gttgccaatg atgttacaga
+     3361 tgagatggtc agactaaact ggctgacgga atttatgcct cttccgacca tcaagcattt
+     3421 tatccgtact cctgatgatg catggttact caccactgcg atccccggaa aaacagcatt
+     3481 ccaggtatta gaagaatatc ctgattcagg tgaaaatatt gttgatgcgc tggcagtgtt
+     3541 cctgcgccgg ttgcattcga ttcctgtttg taattgtcct tttaacagcg atcgcgtatt
+     3601 tcgtctcgct caggcgcaat cacgaatgaa taacggtttg gttgatgcga gtgattttga
+     3661 tgacgagcgt aatggctggc ctgttgaaca agtctggaaa gaaatgcata aacttttgcc
+     3721 attctcaccg gattcagtcg tcactcatgg tgatttctca cttgataacc ttatttttga
+     3781 cgaggggaaa ttaataggtt gtattgatgt tggacgagtc ggaatcgcag accgatacca
+     3841 ggatcttgcc atcctatgga actgcctcgg tgagttttct ccttcattac agaaacggct
+     3901 ttttcaaaaa tatggtattg ataatcctga tatgaataaa ttgcagtttc atttgatgct
+     3961 cgatgagttt ttctaatcag aattggttaa ttggttgtaa cactggcaga gcattacgct
+     4021 gacttgacgg gacggcgcaa gctcatgacc aaaatccctt aacgtgagtt acgcgtcgtt
+     4081 ccactgagcg tcagaccccg tagaaaagat caaaggatct tcttgagatc ctttttttct
+     4141 gcgcgtaatc tgctgcttgc aaacaaaaaa accaccgcta ccagcggtgg tttgtttgcc
+     4201 ggatcaagag ctaccaactc tttttccgaa ggtaactggc ttcagcagag cgcagatacc
+     4261 aaatactgtc cttctagtgt agccgtagtt aggccaccac ttcaagaact ctgtagcacc
+     4321 gcctacatac ctcgctctgc taatcctgtt accagtggct gctgccagtg gcgataagtc
+     4381 gtgtcttacc gggttggact caagacgata gttaccggat aaggcgcagc ggtcgggctg
+     4441 aacggggggt tcgtgcacac agcccagctt ggagcgaacg acctacaccg aactgagata
+     4501 cctacagcgt gagcattgag aaagcgccac gcttcccgaa gggagaaagg cggacaggta
+     4561 tccggtaagc ggcagggtcg gaacaggaga gcgcacgagg gagcttccag ggggaaacgc
+     4621 ctggtatctt tatagtcctg tcgggtttcg ccacctctga cttgagcgtc gatttttgtg
+     4681 atgctcgtca ggggggcgga gcctatggaa aaacgccagc aacgcggcct ttttacggtt
+     4741 cctggccttt tgctggcctt ttgctcacat gtt
+//

--- a/tests/broken_genbank_files/P2RP3_linear.ape
+++ b/tests/broken_genbank_files/P2RP3_linear.ape
@@ -1,0 +1,107 @@
+LOCUS       P2RP3                   4773 bp    DNA        linear     26-NOV-2024
+DEFINITION  .
+ACCESSION
+VERSION
+SOURCE      .
+  ORGANISM  .
+COMMENT
+COMMENT     ApEinfo:methylated:1
+FEATURES             Location/Qualifiers
+     misc_feature    591..822
+                     /locus_tag="attP2R"
+                     /label="attP2R"
+                     /ApEinfo_label="attP2R"
+                     /ApEinfo_fwdcolor="cyan"
+                     /ApEinfo_revcolor="cyan"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+     misc_feature    2746..2977
+                     /locus_tag="attP3"
+                     /label="attP3"
+                     /ApEinfo_label="attP3"
+                     /ApEinfo_fwdcolor="cyan"
+                     /ApEinfo_revcolor="cyan"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {} 0} width 5 offset 0"
+ORIGIN
+        1 ctttcctgcg ttatcccctg attctgtgga taaccgtatt accgcctttg agtgagctga
+       61 taccgctcgc cgcagccgaa cgaccgagcg cagcgagtca gtgagcgagg aagcggaaga
+      121 gcgcccaata cgcaaaccgc ctctccccgc gcgttggccg attcattaat gcagctggca
+      181 cgacaggttt cccgactgga aagcgggcag tgagcgcaac gcaattaata cgcgtaccgc
+      241 tagccaggaa gagtttgtag aaacgcaaaa aggccatccg tcaggatggc cttctgctta
+      301 gtttgatgcc tggcagttta tggcgggcgt cctgcccgcc accctccggg ccgttgcttc
+      361 acaacgttca aatccgctcc cggcggattt gtcctactca ggagagcgtt caccgacaaa
+      421 caacagataa aacgaaaggc ccagtcttcc gactgagcct ttcgttttat ttgatgcctg
+      481 gcagttccct actctcgcgt taacgctagc atggatgttt tcccagtcac gacgttgtaa
+      541 aacgacggcc agtcttaagc tcgggccctg cagctctaga gctcgaattc tacaggtcac
+      601 taataccatc taagtagttg attcatagtg actgcatatg ttgtgtttta cagtattatg
+      661 tagtctgttt tttatgcaaa atctaattta atatattgat atttatatca ttttacgttt
+      721 ctcgttcaac tttcttgtac aaagttggca ttataaaaaa gcattgctta tcaatttgtt
+      781 gcaacgaaca ggtcactatc agtcaaaata aaatcattat ttggagctct agagcgtcga
+      841 ctaagttggc agcatcaccc gacgcacttt gcgccgaata aatacctgtg acggaagatc
+      901 acttcgcaga ataaataaat cctggtgtcc ctgttgatac cgggaagccc tgggccaact
+      961 tttggcgaaa atgagacgtt gatcggcacg taagaggttc caactttcac cataatgaaa
+     1021 taagatcact accgggcgta ttttttgagt tatcgagatt ttcaggagct aaggaagcta
+     1081 aaatggagaa aaaaatcact ggatatacca ccgttgatat atcccaatgg catcgtaaag
+     1141 aacattttga ggcatttcag tcagttgctc aatgtaccta taaccagacc gttcagctgg
+     1201 atattacggc ctttttaaag accgtaaaga aaaataagca caagttttat ccggccttta
+     1261 ttcacattct tgcccgcctg atgaatgctc atccggaatt ccgtatggca atgaaagacg
+     1321 gtgagctggt gatatgggat agtgttcacc cttgttacac cgttttccat gagcaaactg
+     1381 aaacgttttc atcgctctgg agtgaatacc acgacgattt ccggcagttt ctacacatat
+     1441 attcgcaaga tgtggcgtgt tacggtgaaa acctggccta tttccctaaa gggtttattg
+     1501 agaatatgtt tttcgtctca gccaatccct gggtgagttt caccagtttt gatttaaacg
+     1561 tggccaatat ggacaacttc ttcgcccccg ttttcaccat gggcaaatat tatacgcaag
+     1621 gcgacaaggt gctgatgccg ctggcgattc aggttcatca tgccgtctgt gatggcttcc
+     1681 atgtcggcag aatgcttaat gaattacaac agtactgcga tgagtggcag ggcggggcgt
+     1741 aatcgcgtgg atccggctta ctaaaagcca gataacagta tgcgtatttg cgcgctgatt
+     1801 tttgcggtat aagaatatat actgatatgt atacccgaag tatgtcaaaa agaggtgtgc
+     1861 tatgaagcag cgtattacag tgacagttga cagcgacagc tatcagttgc tcaaggcata
+     1921 tatgatgtca atatctccgg tctggtaagc acaaccatgc agaatgaagc ccgtcgtctg
+     1981 cgtgccgaac gctggaaagc ggaaaatcag gaagggatgg ctgaggtcgc ccggtttatt
+     2041 gaaatgaacg gctcttttgc tgacgagaac agggactggt gaaatgcagt ttaaggttta
+     2101 cacctataaa agagagagcc gttatcgtct gtttgtggat gtacagagtg atattattga
+     2161 cacgcccggg cgacggatgg tgatccccct ggccagtgca cgtctgctgt cagataaagt
+     2221 ctcccgtgaa ctttacccgg tggtgcatat cggggatgaa agctggcgca tgatgaccac
+     2281 cgatatggcc agtgtgccgg tctccgttat cggggaagaa gtggctgatc tcagccaccg
+     2341 cgaaaatgac atcaaaaacg ccattaacct gatgttctgg ggaatataaa tgtcaggctc
+     2401 ccttatacac agccagtctg caggtcgata cagtagaaat tacagaaact ttatcacgtt
+     2461 tagtaagtat agaggctgaa aatccagatg aagccgaacg acttgtaaga gaaaagtata
+     2521 agagttgtga aattgttctt gatgcagatg attttcagga ctatgacact agcgtatatg
+     2581 aataggtaga tgtttttatt ttgtcacaca aaaaagaggc tcgcacctct ttttcttatt
+     2641 tctttttatg atttaatacg gcattgagga caatagcgag taggctggat acgacgattc
+     2701 cgtttgagaa gaacatttgg aaggctgtcg gtcgagctcg aattctacag gtcactaata
+     2761 ccatctaagt agttgattca tagtgactgc atatgttgtg ttttacagta ttatgtagtc
+     2821 tgttttttat gcaaaatcta atttaatata ttgatattta tatcatttta cgtttctcgt
+     2881 tcaactttat tatacaaagt tggcattata aaaaagcatt gcttatcaat ttgttgcaac
+     2941 gaacaggtca ctatcagtca aaataaaatc attatttgga gctccatggt agcgttaacg
+     3001 cggccgcgat atcccctata gtgagtcgta ttacatggtc atagctgttt cctggcagct
+     3061 ctggcccgtg tctcaaaatc tctgatgtta cattgcacaa gataaaaata tatcatcatg
+     3121 aacaataaaa ctgtctgctt acataaacag taatacaagg ggtgttatga gccatattca
+     3181 acgggaaacg tcgaggccgc gattaaattc caacatggat gctgatttat atgggtataa
+     3241 atgggctcgc gataatgtcg ggcaatcagg tgcgacaatc tatcgcttgt atgggaagcc
+     3301 cgatgcgcca gagttgtttc tgaaacatgg caaaggtagc gttgccaatg atgttacaga
+     3361 tgagatggtc agactaaact ggctgacgga atttatgcct cttccgacca tcaagcattt
+     3421 tatccgtact cctgatgatg catggttact caccactgcg atccccggaa aaacagcatt
+     3481 ccaggtatta gaagaatatc ctgattcagg tgaaaatatt gttgatgcgc tggcagtgtt
+     3541 cctgcgccgg ttgcattcga ttcctgtttg taattgtcct tttaacagcg atcgcgtatt
+     3601 tcgtctcgct caggcgcaat cacgaatgaa taacggtttg gttgatgcga gtgattttga
+     3661 tgacgagcgt aatggctggc ctgttgaaca agtctggaaa gaaatgcata aacttttgcc
+     3721 attctcaccg gattcagtcg tcactcatgg tgatttctca cttgataacc ttatttttga
+     3781 cgaggggaaa ttaataggtt gtattgatgt tggacgagtc ggaatcgcag accgatacca
+     3841 ggatcttgcc atcctatgga actgcctcgg tgagttttct ccttcattac agaaacggct
+     3901 ttttcaaaaa tatggtattg ataatcctga tatgaataaa ttgcagtttc atttgatgct
+     3961 cgatgagttt ttctaatcag aattggttaa ttggttgtaa cactggcaga gcattacgct
+     4021 gacttgacgg gacggcgcaa gctcatgacc aaaatccctt aacgtgagtt acgcgtcgtt
+     4081 ccactgagcg tcagaccccg tagaaaagat caaaggatct tcttgagatc ctttttttct
+     4141 gcgcgtaatc tgctgcttgc aaacaaaaaa accaccgcta ccagcggtgg tttgtttgcc
+     4201 ggatcaagag ctaccaactc tttttccgaa ggtaactggc ttcagcagag cgcagatacc
+     4261 aaatactgtc cttctagtgt agccgtagtt aggccaccac ttcaagaact ctgtagcacc
+     4321 gcctacatac ctcgctctgc taatcctgtt accagtggct gctgccagtg gcgataagtc
+     4381 gtgtcttacc gggttggact caagacgata gttaccggat aaggcgcagc ggtcgggctg
+     4441 aacggggggt tcgtgcacac agcccagctt ggagcgaacg acctacaccg aactgagata
+     4501 cctacagcgt gagcattgag aaagcgccac gcttcccgaa gggagaaagg cggacaggta
+     4561 tccggtaagc ggcagggtcg gaacaggaga gcgcacgagg gagcttccag ggggaaacgc
+     4621 ctggtatctt tatagtcctg tcgggtttcg ccacctctga cttgagcgtc gatttttgtg
+     4681 atgctcgtca ggggggcgga gcctatggaa aaacgccagc aacgcggcct ttttacggtt
+     4741 cctggccttt tgctggcctt ttgctcacat gtt
+//

--- a/tests/broken_genbank_files/ase1_no_topology.gb
+++ b/tests/broken_genbank_files/ase1_no_topology.gb
@@ -1,0 +1,138 @@
+LOCUS       CU329670                4538 bp    DNA              UNK 01-JAN-1980
+DEFINITION  .
+ACCESSION   SPAPB1A10.09
+VERSION     SPAPB1A10.09
+KEYWORDS    .
+SOURCE      .
+  ORGANISM  .
+            .
+FEATURES             Location/Qualifiers
+     3'UTR           394..676
+                     /systematic_id="SPAPB1A10.08"
+                     /db_xref="PMID:21511999"
+     5'UTR           1001..1173
+                     /systematic_id="SPAPB1A10.09"
+                     /db_xref="PMID:30566651"
+                     /feature_source="evidence=ECO:0000309; source=SO:0001238;
+                     condition=FYECO:0000126; during=GO:0072690; score=146.757;
+                     db_xref=PMID:30566651"
+     CDS             join(1174..1597,1645..3416)
+                     /colour="2"
+                     /primary_name="ase1"
+                     /product="antiparallel microtubule cross-linking factor
+                     Ase1"
+                     /systematic_id="SPAPB1A10.09"
+                     /controlled_curation="term=modification, phosphorylated;
+                     db_xref=PMID:19547744; evidence=IDA; cv=pt_mod;
+                     date=20100606"
+                     /controlled_curation="term=orthologous to S. cerevisiae
+                     YOR058C; date=19700101"
+                     /controlled_curation="term=species distribution, conserved
+                     in eukaryotes; date=20081110"
+                     /controlled_curation="term=species distribution, conserved
+                     in metazoa; date=20081110"
+                     /controlled_curation="term=species distribution, conserved
+                     in vertebrates; date=20081110"
+                     /controlled_curation="term=species distribution,
+                     predominantly single copy (one to one); date=20081110"
+                     /controlled_curation="term=species distribution, conserved
+                     in fungi; date=20081110"
+                     /controlled_curation="term=species distribution, conserved
+                     in eukaryotes only; date=20081110"
+                     /translation="MQTVMMDDIQSTDSIAEKDNHSNNESNFTWKAFREQVEKHFSKIE
+                     RLHQVLGTDGDNSSLFELFTTAMNAQLHEMEQCQKKLEDDCQQRIDSIRFLVSSLKLTD
+                     DTSSLKIESPLIQCLNRLSMVEGQYMAQYDQKLSTIKEMYHKLESYCNRLGSPFVLPDF
+                     ENSFLSDVSDAFTESLRGRINEAEKEIDARLEVINSFEEEILGLWSELGVEPADVPQYE
+                     QLLESHTNRPNDVYVTQELIDQLCKQKEVFSAEKEKRSDHLKSIQSEVSNLWNKLQVSP
+                     NEQSQFGDSSNINQENISLWETELEKLHQLKKEHLPIFLEDCRQQILQLWDSLFYSEEQ
+                     RKSFTPMYEDIITEQVLTAHENYIKQLEAEVSANKSFLSLINRYASLIEGKKELEASSN
+                     DASRLTQRGRRDPGLLLREEKIRKRLSRELPKVQSLLIPEITAWEERNGRTFLFYDEPL
+                     LKICQEATQPKSLYRSASAAANRPKTATTTDSVNRTPSQRGRVAVPSTPSVRSASRAMT
+                     SPRTPLPRVKNTQNPSRSISAEPPSATSTANRRHPTANRIDINARLNSASRSRSANMIR
+                     QGANGSDSNMSSSPVSGNSNTPFNKFPNSVSRNTHFESKSPHPNYSRTPHETYSKASSK
+                     NVPLSPPKQRVVNEHALNIMSEKLQRTNLKEQTPEMDIENSSQNLPFSPMKISPIRASP
+                     VKTIPSSPSPTTNIFSAPLNNITNCTPMEDEWGEEGF*"
+     3'UTR           3417..3538
+                     /systematic_id="SPAPB1A10.09"
+                     /db_xref="PMID:21511999"
+     3'UTR           complement(3510..3690)
+                     /systematic_id="SPAPB1A10.10c"
+                     /db_xref="PMID:21511999"
+ORIGIN
+        1 atcatcagac gtgtatttca caagccagaa gtgcatttgg atccaagtgc ctccatttta
+       61 aatctctcat cttcgcatgg cgaaagcaac ctgacaaatg gtttgctttg tcaaaatttc
+      121 aagctttttc aggatgattg gttgatggag gattgtgcgc cagatgccaa tttcactttg
+      181 tacaccccgc ttcaaccctg ggaaaagcga agtgtgaaac ctgaaatcag acgtcctcga
+      241 ttaaatccta attttttccg agtatttgtt ttagaagctc aaatgcgacg agctggaaag
+      301 ctatcagcaa acactgctgg ccgagcccag ttaatttacc tcccaaagcc tgccgttacc
+      361 ttctccacta gccctttgca tgttgaattg taaaaattta acgcatgact tatatacatt
+      421 tgcattcttc caagctggtt atatttattt tcattttttt ctcacccaat acttttttat
+      481 ccctactgtc tttatggaca atcgactcac aattgtttct ttttgttgta tatgattttt
+      541 tttttaaagg aaatgggttt cgcgatactg ggttgaatcc caattgcggt taatattaca
+      601 taaaataatt ctcccatagt cctagatcct gtctttgaat atgagcaaat aaaagaattg
+      661 aacaaatcat gaatgctttt ctctcttaga tgatattttg tatgcataag tctaattata
+      721 ttgattacga taagacttaa aaagtaagcc tttgtatcct tttaagcagt atttgaattt
+      781 tcttgtatca tattttaggt agagcaaaag ataccagttt gtagaacttt atgtgcttcc
+      841 ttacattggt atatttcagg cacataaata ttcttcaact tacaattcta agtattttgt
+      901 ttatactaaa aggagctgaa taacgtttat acagtgctga cattgaaatc tatttgcttt
+      961 ctttggaata taagcgcatg ctgagttact ttcgcaggcc aagccatatc caaccaccat
+     1021 ttttgtgcca agcttttatg caaggttaat tccttgtact gcttgttatg ttataatata
+     1081 tcaacatctt aacagttttc atatcttcct ttatattcta ttaattgaat ttcaaacatc
+     1141 gttttattga gctcatttac atcaaccggt tcaatgcaaa cagtaatgat ggatgacatt
+     1201 caaagcactg attctattgc tgaaaaagat aatcactcta ataatgaatc taactttact
+     1261 tggaaagcgt ttcgtgaaca agtggaaaag catttttcta aaattgaaag gcttcaccaa
+     1321 gtccttggaa cagatggaga caattcatca ttatttgagt tgtttacaac ggcaatgaat
+     1381 gcccagcttc atgaaatgga acagtgccag aaaaaacttg aagatgactg tcagcaaaga
+     1441 attgattcaa tcagattttt ggtttcctca ttaaagttaa cggatgatac ttctagtctc
+     1501 aaaattgagt ctcctttaat tcagtgtttg aatcgtttgt caatggtaga aggacaatat
+     1561 atggcacagt atgatcaaaa gttaagtacg attaaaggta tgtaatcgtc tttaatttag
+     1621 acttgtgttt taactgatgt atagaaatgt atcacaaatt ggagtcatat tgtaaccgct
+     1681 taggaagtcc gttcgtttta cctgattttg agaattcatt tttatctgat gtatccgatg
+     1741 cttttactga atctttgaga ggacgcatca acgaagccga aaaggagatt gatgcgagat
+     1801 tagaggttat taattccttt gaagaagaaa ttttgggttt gtggtctgaa ctcggtgttg
+     1861 agcccgctga tgttccacaa tacgaacaat tgcttgaatc ccatactaat cgaccaaatg
+     1921 atgtttatgt tactcaagaa cttatcgacc aactttgcaa gcaaaaagaa gttttttccg
+     1981 ctgaaaaaga aaagagaagt gatcatttaa aaagtataca atcagaagtt agcaacttgt
+     2041 ggaataagct tcaagtttct cccaatgaac aaagtcaatt tggcgattca tcaaacatta
+     2101 atcaagaaaa tatttcatta tgggaaactg aacttgaaaa acttcatcag ttaaaaaagg
+     2161 agcatttacc cattttttta gaagactgtc gtcaacaaat tcttcagctt tgggattctc
+     2221 tgttttattc agaagaacaa agaaagtcct ttacacctat gtatgaagac attattacag
+     2281 agcaggttct tacggcccat gaaaactata taaagcaact agaggccgaa gtttctgcta
+     2341 ataagtcctt tttaagctta attaatcgct atgcctcttt aatagaagga aagaaagagc
+     2401 ttgaagctag ttctaatgat gcctctcgtc taacacaacg gggacgccgg gacccaggtt
+     2461 tacttctacg tgaagagaaa atccgtaagc gactttctag agaacttcct aaggttcagt
+     2521 cgctgcttat accagagatt acagcatggg aagaaagaaa tggaaggacg ttcctttttt
+     2581 atgatgaacc acttctcaag atttgccaag aggccactca accaaaatca ttatatagaa
+     2641 gtgcaagtgc tgccgcaaac cgcccgaaaa cagcaactac aacggactct gttaatagaa
+     2701 caccttctca acgagggcgt gtagctgtac cttcaacacc aagtgttagg tccgcttctc
+     2761 gagctatgac gagtccaagg acaccgcttc ctagagtaaa aaacactcaa aatccaagtc
+     2821 gttccattag tgcagaaccg ccatcagcaa ccagtaccgc caatagaaga caccccactg
+     2881 ctaatcgaat tgatataaac gctagattaa acagtgctag tcggtctcga agcgcgaaca
+     2941 tgataagaca aggggcaaat ggtagtgaca gcaatatgtc ttcttcaccc gtttctggaa
+     3001 attccaatac cccttttaac aagtttccaa attctgtatc tcgcaataca cattttgaat
+     3061 ccaagtcacc gcacccaaat tactctcgaa ctcctcatga aacgtattca aaggcttcat
+     3121 ctaagaacgt cccattaagt cctccaaagc agcgtgtagt taatgaacac gctttaaata
+     3181 ttatgtcgga aaaattgcaa agaactaatc tgaaagaaca aacacccgag atggacattg
+     3241 aaaacagctc gcagaacctt cctttttctc ctatgaagat atcccccata agagcatcac
+     3301 ccgtaaagac aattccatca tcaccgtccc ccactaccaa cattttttct gctccactca
+     3361 acaatattac aaattgtaca ccgatggagg atgaatgggg agaagaaggc ttttaagctt
+     3421 cttatttacc taatcgatca aatttaaata tacatatttt tgcatatgaa tacagcatat
+     3481 agataattca taaaagttta ttaactgagg tcataattaa aagactattt acacctaaaa
+     3541 aaaaacgtgt atcaatagag ggaaaagaga agaattaaga acagaaagta accatagttt
+     3601 tgttaaaata gcaatgtaaa aaaatattat gaaaagaaaa cgtatagcac attttgaaat
+     3661 gtaaaagaat ctgagagagc gtgtgaatat ctagcaatta caagaagatg tattattcaa
+     3721 aggctttgaa agaagcaaag gttcagagaa gtcattaaca aagtcatctc tcgagctttc
+     3781 attttctaaa gctaaacgac tgactgtttc gaaaaggtca gtaacgtttg tattttcttt
+     3841 tgcactagct tcaaaatgaa tcatatttga tccatgtttg gatttgcaat agtcaagagc
+     3901 tcgatgaaga gatacggctc gtttagacgc gtctttgtcg atttgatttc caacgataat
+     3961 gaaagggaat gcacattcat cttgtgaagt ttgatataaa aattcttgcc tccagttttc
+     4021 tactgagtca aaagacttcg agttattcac attataaaca attacacaac aatcggcccc
+     4081 tctgtaaaaa gccattccca ggctttgaaa tcgttcttga ccagcagtat cccaaagctg
+     4141 tttataatta gcaaacgaat ttagatgggc ggaacttata ttggaactta cctgtaatgt
+     4201 gaccaatttg tcgtcaacca caacgtcctt ggttaaaaaa tcagcaccga tggtagcttt
+     4261 atattcgcga ctaaactttt gattgacgaa ctaaaatgac gatgttaaca aattgccaaa
+     4321 gcaatactca tagagaagct gatgtaaaga tcgttaacca tatttgagct agtatttaat
+     4381 aacaaagtga ataaatttta aaagcaatca ccttgtagcg acaaataaca acttatcgac
+     4441 ataaaatcaa tgggaaattg cagtattgga ttttacagct caatacaaaa accaaaaaga
+     4501 aaaatatact gaacgtataa aatttaacgc ttcaattg
+//

--- a/tests/broken_genbank_files/base_count_misplaced.gb
+++ b/tests/broken_genbank_files/base_count_misplaced.gb
@@ -1,0 +1,27 @@
+LOCUS       name                     136 bp    DNA     linear   UNK 01-JAN-1980
+DEFINITION  description.
+ACCESSION   id
+VERSION     id
+KEYWORDS    .
+SOURCE      .
+  ORGANISM  .
+            .
+BASE COUNT     1284 a   1068 c   1078 g   1308 t
+FEATURES             Location/Qualifiers
+     protein_bind    1..34
+                     /label="loxP"
+     protein_bind    35..68
+                     /label="lox66"
+     protein_bind    complement(69..102)
+                     /label="lox66"
+     protein_bind    69..102
+                     /label="lox71"
+     protein_bind    complement(35..68)
+                     /label="lox71"
+     protein_bind    103..136
+                     /label="loxP_mutant"
+ORIGIN
+        1 ataacttcgt atattttatt ttatacgaag ttatataact tcgtatattt tattttatac
+       61 gaacggtata ccgttcgtat attttatttt atacgaagtt attaccgttc gtatatttta
+      121 ttttatacga acggta
+//

--- a/tests/broken_genbank_files/pSEVA427.gbk
+++ b/tests/broken_genbank_files/pSEVA427.gbk
@@ -1,0 +1,131 @@
+LOCUS       pSEVA427                4611 bp    DNA     circular
+FEATURES             Location/Qualifiers
+     primer_bind     9..32
+                     /note="F24"
+     terminator      880..982
+                     /note="T0"
+     gene            1100..2005
+                     /gene="aadA"
+     CDS             1100..2005
+                     /dnas_title="spectinomycin adenyltransferase"
+                     /gene="aadA"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="spectinomycin adenyltransferase"
+                     /protein_id="AFV59794.1"
+                     /db_xref="GI:410073705"
+                     /translation="MPRASKQQARYAVGRCLMLWSSNDVTQQGSRPKTKLNIMREAVI
+                     AEVSTQLSEVVGVIERHLEPTLLAVHLYGSAVDGGLKPHSDIDLLVTVTVRLDETTRR
+                     ALINDLLETSASPGESEILRAVEVTIVVHDDIIPWRYPAKRELQFGEWQRNDILAGIF
+                     EPATIDIDLAILLTKAREHSVALVGPAAEELFDPVPEQDLFEALNETLTLWNSPPDWA
+                     GDERNVVLTLSRIWYSAVTGKIAPKDVAADWAMERLPAQYQPVILEARQAYLGQEEDR
+                     LASRADQLEEFVHYVKGEITKVVGK"
+     misc_feature    2026..2261
+                     /note="oriT"
+     gene            complement(2320..3468)
+                     /gene="trfA"
+     CDS             complement(2320..3468)
+                     /dnas_title="replication protein"
+                     /gene="trfA"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="replication protein"
+                     /protein_id="AFV59795.1"
+                     /db_xref="GI:410073706"
+                     /translation="MNRTFDRKAYRQELIDAGFSAEDAETIASRTVMRAPRETFQSVG
+                     SIVQQATAKIERDSVQLAPPALPAPSAAVERSRRLEQEAAGLAKSMTIDTRGTMTTKK
+                     RKTAGEDLAKQVSEAKQAALLKHTKQQIKEMQLSLFDIAPWPDTMRAMPNDTARSALF
+                     TTRNKKIPREALQNKVIFHVNKDVKITYTGVELRADDDELVWQQVLEYAKRTPIGEPI
+                     TFTFYELCQDLGWSINGRYYTKAEECLSRLQATAMGFTSDRVGHLESVSLLHRFRVLD
+                     RGKKTSRCQVLIDEEIVVLFAGDHYTKFIWEKYRKLSPTARRMFDYFSSHREPYPLKL
+                     ETFRLMCGSDSTRVKKWREQVGEACEELRGSGLVEHAWVNDDLVHCKR"
+     terminator      4506..4610
+                     /note="T1"
+     gene            127..843
+                     /gene="gfp"
+                     /label=gfp
+     misc_feature    113..119
+                     /note="RBS"
+     misc_feature    33..112
+                     /note="MCS"
+     source          1..4611
+                     /dnas_title="pSEVA427"
+ORIGIN
+        1 ttaattaaag cggataacaa tttcacacag gaggccgcct aggccgcggc cgcgcgaatt
+       61 cgagctcggt acccggggat cctctagagt cgacctgcag gcatgcaAGC TTAGGAGGAA
+      121 AAACATATGA GTAAAGGAGA AGAACTTTTC ACTGGAGTTG TCCCAATTCT TGTTGAATTA
+      181 GATGGTGATG TTAATGGGCA CAAATTTTCT GTCAGTGGAG AGGGTGAAGG TGATGCAACA
+      241 TACGGAAAAC TTACCCTTAA ATTTATTTGC ACTACTGGAA AACTACCTGT TCCATGGCCA
+      301 ACACTTGTCA CTACTTTGAC TTATGGTGTT CAATGCTTTT CAAGATACCC AGATCATATG
+      361 AAACGGCATG ACTTTTTCAA GAGTGCCATG CCCGAAGGTT ATGTACAGGA AAGAACTATA
+      421 TTTTTCAAAG ATGACGGGAA CTACAAGACA CGTGCTGAAG TCAAGTTTGA AGGTGATACC
+      481 CTTGTTAATA GAATCGAGTT AAAAGGTATT GATTTTAAAG AAGATGGAAA CATTCTTGGA
+      541 CACAAATTGG AATACAACTA TAACTCACAC AATGTATACA TCATGGCAGA CAAACAAAAG
+      601 AATGGAATCA AAGTTAACTT CAAAATTAGA CACAACATTG AAGATGGAAG CGTTCAACTA
+      661 GCAGACCATT ATCAACAAAA TACTCCAATT GGCGATGGCC CTGTCCTTTT ACCAGACAAC
+      721 CATTACCTGT CCACACAATC TGCCCTTTCG AAAGATCCCA ACGAAAAGAG AGACCACATG
+      781 GTCCTTCTTG AGTTTGTAAC AGCTGCTGGG ATTACACATG GCATGGATGA ACTATACAAA
+      841 TAGcattcgt atgtctgcta tttcgcgtat agaActagtc ttggactcct gttgatagat
+      901 ccagtaatga cctcagaact ccatctggat ttgttcagaa cgctcggttg ccgccgggcg
+      961 ttttttattg gtgagaatcc aggggtcccc aataattacg atttacgtat ttaaatgaac
+     1021 cttgaccgaa cgcagcggtg gtaacggcgc agtggcggtt ttcatggctt gttatgactg
+     1081 tttttttggg gtacagtcta tgcctcgggc atccaagcag caagcgcgtt acgccgtggg
+     1141 tcgatgtttg atgttatgga gcagcaacga tgttacgcag cagggcagtc gccctaaaac
+     1201 aaagttaaac atcatgaggg aagcggtgat cgccgaagta tcgactcaac tatcagaggt
+     1261 agttggcgtc atcgagcgcc atctcgaacc gacgttgctg gccgtacatt tgtacggctc
+     1321 cgcagtggat ggcggcctga agccacacag tgatattgat ttgctggtta cggtgaccgt
+     1381 aaggcttgat gaaacaacgc ggcgagcttt gatcaacgac cttttggaaa cttcggcttc
+     1441 ccctggagag agcgagattc tccgcgctgt agaagtcacc attgttgtgc acgacgacat
+     1501 cattccgtgg cgttatccag ctaagcgcga actgcaattt ggagaatggc agcgcaatga
+     1561 cattcttgca ggtatcttcg agccagccac gatcgacatt gatctggcta tcttgctgac
+     1621 aaaagcaaga gaacatagcg ttgccttggt aggtccagcg gcggaggaac tctttgatcc
+     1681 ggttcctgaa caggatctat ttgaggcgct aaatgaaacc ttaacgctat ggaactcgcc
+     1741 gcccgactgg gctggcgatg agcgaaatgt agtgcttacg ttgtcccgca tttggtacag
+     1801 cgcagtaacc ggcaaaatcg cgccgaagga tgtcgctgcc gactgggcaa tggagcgcct
+     1861 gccggcccag tatcagcccg tcatacttga agctagacag gcttatcttg gacaagaaga
+     1921 agatcgcttg gcctcgcgcg cagatcagtt ggaagaattt gtccactacg tgaaaggcga
+     1981 gatcaccaag gtagtcggca aataagacaa ttgtcctttt ccgctgcata accctgcttc
+     2041 ggggtcatta tagcgatttt ttcggtatat ccatcctttt tcgcacgata tacaggattt
+     2101 tgccaaaggg ttcgtgtaga ctttccttgg tgtatccaac ggcgtcagcc gggcaggata
+     2161 ggtgaagtag gcccacccgc gagcgggtgt tccttcttca ctgtccctta ttcgcacctg
+     2221 gcggtgctca acgggaatcc tgctctgcga ggctggccgt aggccggccg cgatgcaggt
+     2281 ggctgctgaa cccccagccg gaactgaccc cacaaggccc tagcgtttgc aatgcaccag
+     2341 gtcatcattg acccaggcgt gttccaccag gccgctgcct cgcaactctt cgcaggcttc
+     2401 gccgacctgc tcgcgccact tcttcacgcg ggtggaatcc gatccgcaca tgaggcggaa
+     2461 ggtttccagc ttgagcgggt acggctcccg gtgcgagctg aaatagtcga acatccgtcg
+     2521 ggccgtcggc gacagcttgc ggtacttctc ccatatgaat ttcgtgtagt ggtcgccagc
+     2581 aaacagcacg acgatttcct cgtcgatcag gacctggcaa cgggacgttt tcttgccacg
+     2641 gtccaggacg cggaagcggt gcagcagcga caccgattcc aggtgcccaa cgcggtcgga
+     2701 cgtgaagccc atcgccgtcg cctgtaggcg cgacaggcat tcctcggcct tcgtgtaata
+     2761 ccggccattg atcgaccagc ccaggtcctg gcaaagctcg tagaacgtga aggtgatcgg
+     2821 ctcgccgata ggggtgcgct tcgcgtactc caacacctgc tgccacacca gttcgtcatc
+     2881 gtcggcccgc agctcgacgc cggtgtaggt gatcttcacg tccttgttga cgtggaaaat
+     2941 gaccttgttt tgcagcgcct cgcgcgggat tttcttgttg cgcgtggtga acagggcaga
+     3001 gcgggccgtg tcgtttggca tcgctcgcat cgtgtccggc cacggcgcaa tatcgaacaa
+     3061 ggaaagctgc atttccttga tctgctgctt cgtgtgtttc agcaacgcgg cctgcttggc
+     3121 ttcgctgacc tgttttgcca ggtcctcgcc ggcggttttt cgcttcttgg tcgtcatagt
+     3181 tcctcgcgtg tcgatggtca tcgacttcgc caaacctgcc gcctcctgtt cgagacgacg
+     3241 cgaacgctcc acggcggccg atggcgcggg cagggcaggg ggagccagtt gcacgctgtc
+     3301 gcgctcgatc ttggccgtag cttgctggac tatcgagccg acggactgga aggtttcgcg
+     3361 gggcgcacgc atgacggtgc ggcttgcgat ggtttcggca tcctcggcgg aaaaccccgc
+     3421 gtcgatcagt tcttgcctgt atgccttccg gtcaaacgtc cgattcattc accctccttg
+     3481 cgggattgcc ccggaattaa ttccccggat cgatccgtcg atcttgatcc cctgcgccat
+     3541 cagatccttg gcggcaagaa agccatccag tttactttgc agggcttccc aaccttacca
+     3601 gagggcgccc cagctggcaa ttccggttcg cttgctgtcc ataaaaccgc ccagtctagc
+     3661 tatcgccatg taagcccact gcaagctacc tgctttctct ttgcgcttgc gttttccctt
+     3721 gtccagatag cccagtagct gacattcatc cggggtcagc accgtttctg cggactggct
+     3781 ttctacgtgg ctgccatttt tggggtgagg ccgttcgcgg ccgaggggcg cagcccctgg
+     3841 ggggatggga ggcccgcgtt agcgggccgg gagggttcga gaaggggggg cacccccctt
+     3901 cggcgtgcgc ggtcacgcgc acagggcgca gccctggtta aaaacaaggt ttataaatat
+     3961 tggtttaaaa gcaggttaaa agacaggtta gcggtggccg aaaaacgggc ggaaaccctt
+     4021 gcaaatgctg gattttctgc ctgtggacag cccctcaaat gtcaataggt gcgcccctca
+     4081 tctgtcagca ctctgcccct caagtgtcaa ggatcgcgcc cctcatctgt cagtagtcgc
+     4141 gcccctcaag tgtcaatacc gcagggcact tatccccagg cttgtccaca tcatctgtgg
+     4201 gaaactcgcg taaaatcagg cgttttcgcc gatttgcgag gctggccagc tccacgtcgc
+     4261 cggccgaaat cgagcctgcc cctcatctgt caacgccgcg ccgggtgagt cggcccctca
+     4321 agtgtcaacg tccgcccctc atctgtcagt gagggccaag ttttccgcga ggtatccaca
+     4381 acgccggcgg ccctacatgg ctctgctgta gtgagtgggt tgcgctccgg cagcggtcct
+     4441 gatcccccgc agaaaaaaag gatctcaaga agatcctttg atcttttcta cggcgcgccc
+     4501 agctgtctag ggcggcggat ttgtcctact caggagagcg ttcaccgaca aacaacagat
+     4561 aaaacgaaag gcccagtctt tcgactgagc ctttcgtttt atttgatgcc t
+//

--- a/tests/test_module_contig2.py
+++ b/tests/test_module_contig2.py
@@ -15,6 +15,7 @@ c = Dseqrecord("tattctggctgtatcGGGGGtacgatgctatactg", name="three")
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.filterwarnings("ignore::pytest.PytestReturnNotNoneWarning")
 def test_contig_linear():
 
     asm = Assembly((a, b, c), limit=14)
@@ -45,10 +46,11 @@ def test_contig_linear():
         "                                      tattctggctgtatcGGGGGtacgatgctatactg\n"
     )
 
-    cont.figure_mpl()
+    return cont.figure_mpl()  # type: ignore
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.filterwarnings("ignore::pytest.PytestReturnNotNoneWarning")
 def test_contig_circular():
 
     asm = Assembly((a, b, c), limit=14)
@@ -84,7 +86,7 @@ def test_contig_circular():
 
     assert fig == cont.figure()
 
-    cont.figure_mpl()
+    return cont.figure_mpl()  # type: ignore
 
 
 def test_reverse_complement():
@@ -188,6 +190,7 @@ def test_linear():
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.filterwarnings("ignore::pytest.PytestReturnNotNoneWarning")
 def test_mpl1():
 
     a = Dseqrecord(
@@ -201,10 +204,11 @@ def test_mpl1():
     asm = Assembly((a, b), limit=20)
     cps = asm.assemble_circular()
     cp = cps[0]
-    cp.figure_mpl()
+    return cp.figure_mpl()  # type: ignore
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.filterwarnings("ignore::pytest.PytestReturnNotNoneWarning")
 def test_mpl2():
 
     x = Dseqrecord(
@@ -222,10 +226,11 @@ def test_mpl2():
     asm2 = Assembly((x, y, z), limit=20)
     cps2 = asm2.assemble_circular()
     cp2 = cps2[0]
-    cp2.figure_mpl()
+    return cp2.figure_mpl()  # type: ignore
 
 
 @pytest.mark.mpl_image_compare
+@pytest.mark.filterwarnings("ignore::pytest.PytestReturnNotNoneWarning")
 def test_mpl3():
 
     p = {}
@@ -302,4 +307,4 @@ def test_mpl3():
 
     cp3 = cps3[0]
 
-    cp3.figure_mpl()
+    return cp3.figure_mpl()  # type: ignore

--- a/tests/test_module_contig2.py
+++ b/tests/test_module_contig2.py
@@ -45,7 +45,7 @@ def test_contig_linear():
         "                                      tattctggctgtatcGGGGGtacgatgctatactg\n"
     )
 
-    return cont.figure_mpl()
+    cont.figure_mpl()
 
 
 @pytest.mark.mpl_image_compare
@@ -84,7 +84,7 @@ def test_contig_circular():
 
     assert fig == cont.figure()
 
-    return cont.figure_mpl()
+    cont.figure_mpl()
 
 
 def test_reverse_complement():
@@ -201,7 +201,7 @@ def test_mpl1():
     asm = Assembly((a, b), limit=20)
     cps = asm.assemble_circular()
     cp = cps[0]
-    return cp.figure_mpl()
+    cp.figure_mpl()
 
 
 @pytest.mark.mpl_image_compare
@@ -222,7 +222,7 @@ def test_mpl2():
     asm2 = Assembly((x, y, z), limit=20)
     cps2 = asm2.assemble_circular()
     cp2 = cps2[0]
-    return cp2.figure_mpl()
+    cp2.figure_mpl()
 
 
 @pytest.mark.mpl_image_compare
@@ -302,4 +302,4 @@ def test_mpl3():
 
     cp3 = cps3[0]
 
-    return cp3.figure_mpl()
+    cp3.figure_mpl()

--- a/tests/test_module_parsers.py
+++ b/tests/test_module_parsers.py
@@ -425,21 +425,18 @@ def test_parse_is_path():
     assert len(parse(file_name, is_path=True)) == 1
 
 
-def test_permisive_parser_ape_topology():
-    assert read(f"{test_files}/broken_genbank_files/P2RP3.ape", "r").circular is True
-    assert (
-        read(f"{test_files}/broken_genbank_files/P2RP3_linear.ape", "r").circular
-        is False
-    )
+def test_permissive_parser_ape_topology():
+    assert read(f"{test_files}/broken_genbank_files/P2RP3.ape").circular is True
+    assert read(f"{test_files}/broken_genbank_files/P2RP3_linear.ape").circular is False
 
 
 def test_permisive_parser_no_topology():
-    seq = read(f"{test_files}/broken_genbank_files/ase1_no_topology.gb", "r")
+    seq = read(f"{test_files}/broken_genbank_files/ase1_no_topology.gb")
     assert seq.annotations["topology"] == "linear"
 
 
 def test_permissive_parser_malformed_LOCUS_line():
-    assert read(f"{test_files}/broken_genbank_files/pSEVA427.gbk", "r").circular is True
+    assert read(f"{test_files}/broken_genbank_files/pSEVA427.gbk").circular is True
 
 
 def test_permissive_parser_base_count_misplaced():

--- a/tests/test_module_parsers.py
+++ b/tests/test_module_parsers.py
@@ -414,8 +414,8 @@ def test_parse_is_path():
     # Should throw an error if the path is not a file:
     text_input = ">seq\nACGT"
     with pytest.raises(FileNotFoundError):
-        # We can't pass a linebreak because it breaks tests in windows
-        parse(">seqACGT", is_path=True)
+        # We can't pass a linebreak nor > because it breaks tests in windows
+        parse("ACGT", is_path=True)
     assert len(parse(text_input, is_path=False)) == 1
 
     # Should throw an error if passing a path as no is_path

--- a/tests/test_module_parsers.py
+++ b/tests/test_module_parsers.py
@@ -6,6 +6,17 @@ test parse
 
 import os
 
+from Bio.SeqIO import parse as BPparse
+from pydna.parsers import (
+    embl_gb_fasta,
+    extract_from_text,
+    parse,
+    parse_primers,
+    parse_snapgene,
+)
+from pydna.readers import read
+import pytest
+
 test_files = os.path.join(os.path.dirname(__file__))
 
 
@@ -21,8 +32,6 @@ def test_extract_from_text():
             ID
             //
             """
-    from pydna.parsers import extract_from_text
-
     seqs, gaps = extract_from_text(text)
     assert seqs == (">a\naaaa\n", "LOCUS\n//", ">b\nbbbbbb\n", "ID\n//")
     assert [g.strip() for g in gaps] == ["", "", "", "", ""]
@@ -60,8 +69,6 @@ def test_extract_from_text():
         "",
         "comment 4",
     )
-
-    from pydna.parsers import embl_gb_fasta
 
     text = """\
             LOCUS       New_linear_DNA             2 bp    DNA     linear       29-MAR-2024
@@ -132,10 +139,7 @@ def test_extract_from_text():
 
 
 def test_parse1():
-    from pydna.parsers import parse
-    from pydna.readers import read
-
-    """ test parsing fasta sequences from a text"""
+    """test parsing fasta sequences from a text"""
 
     text = """
             points....: 1
@@ -248,10 +252,6 @@ def test_parse1():
 
 
 def test_parse2():
-    from pydna.parsers import parse
-
-    # from pydna.readers import read
-
     seqs = parse("RefDataBjorn.fas")
 
     assert len(seqs) == 771
@@ -270,8 +270,6 @@ def test_parse2():
 
 
 def test_parse_primers():
-    from pydna.parsers import parse_primers
-
     data = str(">1\n" "aaaa\n" ">2\n" "cccc\n")
     parse_primers(data)
 
@@ -288,8 +286,6 @@ def test_parse_primers():
 
 
 def test_parse_error():
-    from pydna.parsers import parse
-
     data = """
 LOCUS
 DATA_IS_NOT_A_SEQUENCE
@@ -298,8 +294,6 @@ DATA_IS_NOT_A_SEQUENCE
 
 
 def test_parse_list():
-    from pydna.parsers import parse_primers
-
     data = str(">1\n" "aaaa\n" ">2\n" "cccc\n")
 
     assert [str(x.seq) for x in parse_primers([data, data])] == [
@@ -311,12 +305,6 @@ def test_parse_list():
 
 
 def test_misc_parse():
-
-    from pydna.parsers import parse
-
-    # from Bio.SeqIO import read as BPread
-    from Bio.SeqIO import parse as BPparse
-
     # q = BPread("read1.gb", "gb")
     # w = BPread("read2.gb", "gb")
     # e = BPread("read3.fasta", "fasta")
@@ -346,8 +334,6 @@ def test_misc_parse():
 
 
 def test_dna2949():
-    from pydna.parsers import parse
-
     with open("dna2943.gb") as f:
         f.read()
     seqlist = parse("dna2943.gb", ds=True)
@@ -357,8 +343,6 @@ def test_dna2949():
 
 
 def proteins():
-    from pydna.parsers import embl_gb_fasta
-
     proteins = """\
     >pdb|3VQM|V Chain V, C-terminal peptide from Small heat shock protein StHsp14.0
     VIKIE
@@ -408,8 +392,6 @@ def proteins():
 
 
 def test_parse_snapgene():
-    from pydna.parsers import parse_snapgene
-
     # Parse circular snapgene file
     seq = parse_snapgene(
         os.path.join(test_files, "gateway_manual_cloning/pDONRtm201.dna")
@@ -426,3 +408,38 @@ def test_parse_snapgene():
     )[0]
     assert not seq.circular
     assert len(seq) == 2304
+
+
+def test_parse_is_path():
+    # Should throw an error if the path is not a file:
+    text_input = ">seq\nACGT"
+    with pytest.raises(FileNotFoundError):
+        parse(text_input, is_path=True)
+    assert len(parse(text_input, is_path=False)) == 1
+
+    # Should throw an error if passing a path as no is_path
+    file_name = os.path.join(test_files, "pAG25.gb")
+
+    assert len(parse(file_name, is_path=False)) == 0
+    assert len(parse(file_name, is_path=True)) == 1
+
+
+def test_permisive_parser_ape_topology():
+    assert read(f"{test_files}/broken_genbank_files/P2RP3.ape", "r").circular is True
+    assert (
+        read(f"{test_files}/broken_genbank_files/P2RP3_linear.ape", "r").circular
+        is False
+    )
+
+
+def test_permisive_parser_no_topology():
+    seq = read(f"{test_files}/broken_genbank_files/ase1_no_topology.gb", "r")
+    assert seq.annotations["topology"] == "linear"
+
+
+def test_permissive_parser_malformed_LOCUS_line():
+    assert read(f"{test_files}/broken_genbank_files/pSEVA427.gbk", "r").circular is True
+
+
+def test_permissive_parser_base_count_misplaced():
+    read(f"{test_files}/broken_genbank_files/base_count_misplaced.gb")

--- a/tests/test_module_parsers.py
+++ b/tests/test_module_parsers.py
@@ -414,7 +414,8 @@ def test_parse_is_path():
     # Should throw an error if the path is not a file:
     text_input = ">seq\nACGT"
     with pytest.raises(FileNotFoundError):
-        parse(text_input, is_path=True)
+        # We can't pass a linebreak because it breaks tests in windows
+        parse(">seqACGT", is_path=True)
     assert len(parse(text_input, is_path=False)) == 1
 
     # Should throw an error if passing a path as no is_path


### PR DESCRIPTION
Hi @BjornFJohansson, this PR moves a bit of code from OpenCloning for some edge-case when ape / genbank parsing, mostly of LOCUS lines (see gb files are added, of which the topology was not being parsed correclty in the past -ape circular file- or could not be parsed at all -pSEVA427.gbk- ).

It also handles an [edge case](https://github.com/biopython/biopython/issues/5172) that I tried to get into biopython but not sure will go in.

In addition, i added an extra optional parameter `is_path=None` to `read` and `parse` (#428) to allow the user to specify whether the passed argument is a path or the text content of a file. I also improved the logic around determining whether something is a path to use if statements rather than error handling.

closes #428
closes #76 (my first issue! I think)

Then I also made a few changes to suppress test warnings in genbankfixer.py test_module_contig2.py and pyproject.toml, but nothing in those files is really changed