### PR TITLE
Dseq join that respects sticky ends

### DIFF
--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -3056,3 +3056,30 @@ class Dseq(Seq):
 
         """
         return get_parts(self._data.decode("ascii"))
+
+    def join(self, fragments):
+        """
+        Join an iterable of Dseqs with this instance as the separator.
+
+        Example:
+
+        >>> sep = Dseq("a")
+        >>> joined = sep.join([Dseq("G"), Dseq("A"), Dseq("T"), Dseq("C")])
+        >>> joined
+        Dseq(-7)
+        GaAaTaC
+        CtTtAtG
+
+        """
+        it = iter(fragments)
+        try:
+            result = next(it)  # first element (no leading separator)
+        except StopIteration:
+            # Empty iterable -> return empty Dseq in analogy with
+            # str.join
+            return Dseq("")
+
+        # Interleave: result = first + sep + 2nd + sep + 3rd + ...
+        for x in it:
+            result = result + self + x
+        return result

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -1754,3 +1754,38 @@ def test_melt_ss_dna():
 
         assert new_ds.melt_ss_dna(2)[1][0]._data == b"xe"
         assert new_ds.melt_ss_dna(2)[0] == product.shifted(shift)
+
+
+def test_join():
+
+    assert Dseq("").join([Dseq("a")] * 3) == Dseq("aaa")
+    assert Dseq("").join([Dseq("PaQ")] * 3) == Dseq.from_representation(
+        """
+        Dseq(-7)
+        GaGaGa
+         tCtCtC
+        """
+    )
+    assert Dseq("").join([Dseq("QaP")] * 3) == Dseq.from_representation(
+        """
+        Dseq(-7)
+         aGaGaG
+        CtCtCt
+        """
+    )
+    with pytest.raises(TypeError):
+        assert Dseq("").join([Dseq("PaQ"), Dseq("QaP")])
+    assert Dseq("PaQ").join([Dseq("PaQ"), Dseq("PaQ")]) == Dseq.from_representation(
+        """
+        Dseq(-7)
+        GaGaGa
+         tCtCtC
+        """
+    )
+    assert Dseq("PaQ").join([Dseq("PaQ")]) == Dseq.from_representation(
+        """
+        Dseq(-3)
+        Ga
+         tC
+        """
+    )

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -1789,3 +1789,95 @@ def test_join():
          tC
         """
     )
+
+
+def tests_misc():
+    from pydna.dseq import Dseq
+    from Bio.Restriction import Acc65I, NlaIV, KpnI, NotI
+
+    assert Dseq("aa").cut(NotI) == ()
+
+    obj = Dseq("GGTACC")
+
+    obj_Acc65I = obj.cut(Acc65I)
+    obj_KpnI = obj.cut(KpnI)
+    obj_NlaIV = obj.cut(NlaIV)
+
+    assert obj_Acc65I == (Dseq("GQZFJ"), Dseq("PXEIC"))
+    assert obj_KpnI == (Dseq("GPXEI"), Dseq("QZFJC"))
+    assert obj_NlaIV == (Dseq("GGT"), Dseq("ACC"))
+
+    assert obj == Dseq("").join(obj_Acc65I)
+    cobj = obj.looped()
+
+    for i in range(len(cobj) + 1):
+        shifted_obj = cobj.shifted(i)
+
+        assert shifted_obj.cut(Acc65I) == (Dseq("").join(obj_Acc65I[::-1]),)
+        assert shifted_obj.cut(KpnI) == (Dseq("").join(obj_KpnI[::-1]),)
+        assert shifted_obj.cut(NlaIV) == (Dseq("").join(obj_NlaIV[::-1]),)
+
+    from Bio.Restriction import (
+        KpnI,
+        Acc65I,
+        NlaIV,
+    )
+
+    obj = Dseq("GGTACCnnnGGtaCC")
+
+    obj_Acc65I = obj.cut(Acc65I)
+    obj_KpnI = obj.cut(KpnI)
+    obj_NlaIV = obj.cut(NlaIV)
+
+    assert obj_Acc65I == (Dseq("GQZFJ"), Dseq("PXEICnnnGQzfJ"), Dseq("PxeIC"))
+    assert obj_KpnI == (Dseq("GPXEI"), Dseq("QZFJCnnnGPxeI"), Dseq("QzfJC"))
+    assert obj_NlaIV == (Dseq("GGT"), Dseq("ACCnnnGGt"), Dseq("aCC"))
+
+
+def test_shifted2():
+    from pydna.dseq import Dseq
+
+    a = Dseq("gatc", circular=True)
+
+    assert a.shifted(1) == Dseq("atcg", circular=True)
+
+    assert a.shifted(4) == a
+
+    b = Dseq("gatc", circular=False)
+    with pytest.raises(TypeError):
+        b.shifted(1)
+
+    # Shifted with zero gives a copy of the sequence, not the same sequence
+    assert a.shifted(0) == a
+    assert a.shifted(0) is not a
+
+    x = Dseq("TPGJG", circular=True)
+
+    s = """
+    TGG G
+    A CGC
+
+    GG GT
+     CGCA
+
+    G GTG
+    CGCA
+
+     GTGG
+    GCA C
+
+    GTGG
+    CA CG
+
+    TGG G
+    A CGC
+    """
+
+    lines = [l.strip() for l in s.splitlines() if l.strip()]
+    repr_strings = [
+        "{}\n{}".format(lines[i], lines[i + 1]) for i in range(0, len(lines), 2)
+    ]
+
+    for i in range(len(x)):
+        assert x.shifted(i)._data == x._data[i:] + x._data[:i]
+        repr_strings[i] == "\n".join(repr(x).splitlines()[1:])


### PR DESCRIPTION
Added a join method to Dseq as the one in Bio.Seq cast the sequence as a string. Also added a short test.