### PR TITLE
Parser update

### DIFF
--- a/src/pydna/parsers.py
+++ b/src/pydna/parsers.py
@@ -172,26 +172,17 @@ def embl_gb_fasta(text):
                     handle.close()
                     continue
                 else:
-                    # hack to pick up molecule_type from FASTA header line
-                    if "protein" in first_line:
-                        parsed.annotations["molecule_type"] = "protein"
-                        parsed.annotations["topology"] = "linear"
-                    else:
-                        parsed.annotations["molecule_type"] = "DNA"
-            # else:
-            #     if _re.match(r"LOCUS\s+(\S+)\s+(\S+)\s+aa", " ".join(first_line)):
-            #         parsed.annotations["molecule_type"] = "protein"
-            #         parsed.annotations["topology"] = "linear"
+                    # molecule_type is not set by the Biopython FASTA parser
+                    parsed.annotations["molecule_type"] = "DNA"
         handle.close()
         # hack to pick up topology from FASTA and malformed gb files
         first_line = chunk.splitlines()[0].lower().split()
         parsed.annotations["topology"] = "linear"
         if "circular" in first_line:
             parsed.annotations["topology"] = "circular"
-        # assert parsed.annotations.get("topology"), "topology must be set"
-        assert parsed.annotations.get("molecule_type"), "molecule_type  must be set"
-        if not parsed.annotations.get("molecule_type"):
-            print(parsed)
+        molecule_type = parsed.annotations.get("molecule_type")
+        assert molecule_type, "molecule_type must be set"
+        assert molecule_type != "protein", "molecule_type can not be 'protein'"
         result_list.append(parsed)
     return tuple(result_list)
 

--- a/tests/sequence-OST4-Genbank.gp
+++ b/tests/sequence-OST4-Genbank.gp
@@ -1,0 +1,105 @@
+LOCUS       DAA11634                  36 aa            linear   PLN 22-JAN-2026
+DEFINITION  TPA_inf: olichyl-diphosphooligosaccharide--protein glycotransferase
+            OST4 [Saccharomyces cerevisiae S288C].
+ACCESSION   DAA11634
+VERSION     DAA11634.1
+DBLINK      BioProject: PRJNA43747
+DBSOURCE    accession BK006938.2
+KEYWORDS    Third Party Data; TPA.
+SOURCE      Saccharomyces cerevisiae S288C
+  ORGANISM  Saccharomyces cerevisiae S288C
+            Eukaryota; Fungi; Dikarya; Ascomycota; Saccharomycotina;
+            Saccharomycetes; Saccharomycetales; Saccharomycetaceae;
+            Saccharomyces.
+REFERENCE   1  (residues 1 to 36)
+  AUTHORS   Goffeau,A., Barrell,B.G., Bussey,H., Davis,R.W., Dujon,B.,
+            Feldmann,H., Galibert,F., Hoheisel,J.D., Jacq,C., Johnston,M.,
+            Louis,E.J., Mewes,H.W., Murakami,Y., Philippsen,P., Tettelin,H. and
+            Oliver,S.G.
+  TITLE     Life with 6000 genes
+  JOURNAL   Science 274 (5287), 546 (1996)
+   PUBMED   8849441
+REFERENCE   2  (residues 1 to 36)
+  AUTHORS   Jacq,C., Alt-Morbe,J., Andre,B., Arnold,W., Bahr,A., Ballesta,J.P.,
+            Bargues,M., Baron,L., Becker,A., Biteau,N., Blocker,H., Blugeon,C.,
+            Boskovic,J., Brandt,P., Bruckner,M., Buitrago,M.J., Coster,F.,
+            Delaveau,T., del Rey,F., Dujon,B., Eide,L.G.,
+            Garcia-Cantalejo,J.M., Goffeau,A., Gomez-Peris,A., Zaccaria,P. et
+            al.
+  TITLE     The nucleotide sequence of Saccharomyces cerevisiae chromosome IV
+  JOURNAL   Nature 387 (6632 SUPPL), 75-78 (1997)
+   PUBMED   9169867
+REFERENCE   3  (residues 1 to 36)
+  AUTHORS   Engel,S.R., Wong,E.D., Nash,R.S., Aleksander,S., Alexander,M.,
+            Douglass,E., Karra,K., Miyasato,S.R., Simison,M., Skrzypek,M.S.,
+            Weng,S. and Cherry,J.M.
+  TITLE     New data and collaborations at the Saccharomyces Genome Database:
+            updated reference genome, alleles, and the Alliance of Genome
+            Resources
+  JOURNAL   Genetics 220 (4) (2022)
+   PUBMED   34897464
+REFERENCE   4  (residues 1 to 36)
+  CONSRTM   Saccharomyces Genome Database
+  TITLE     Direct Submission
+  JOURNAL   Submitted (11-DEC-2009) Department of Genetics, Stanford
+            University, Stanford, CA 94305-5120, USA
+REFERENCE   5  (residues 1 to 36)
+  CONSRTM   Saccharomyces Genome Database
+  TITLE     Direct Submission
+  JOURNAL   Submitted (31-MAR-2011) Department of Genetics, Stanford
+            University, Stanford, CA 94305-5120, USA
+  REMARK    Sequence update by submitter
+REFERENCE   6  (residues 1 to 36)
+  CONSRTM   Saccharomyces Genome Database
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-MAY-2012) Department of Genetics, Stanford
+            University, Stanford, CA 94305-5120, USA
+  REMARK    Protein update by submitter
+REFERENCE   7  (residues 1 to 36)
+  CONSRTM   Saccharomyces Genome Database
+  TITLE     Direct Submission
+  JOURNAL   Submitted (06-FEB-2013) Department of Genetics, Stanford
+            University, Stanford, CA 94305-5120, USA
+  REMARK    Protein update by submitter
+REFERENCE   8  (residues 1 to 36)
+  CONSRTM   Saccharomyces Genome Database
+  TITLE     Direct Submission
+  JOURNAL   Submitted (16-JAN-2015) Department of Genetics, Stanford
+            University, Stanford, CA 94305-5120, USA
+  REMARK    Protein update by submitter
+COMMENT     Method: conceptual translation.
+FEATURES             Location/Qualifiers
+     source          1..36
+                     /organism="Saccharomyces cerevisiae S288C"
+                     /strain="S288C"
+                     /db_xref="taxon:559292"
+                     /chromosome="IV"
+     Protein         1..36
+                     /product="olichyl-diphosphooligosaccharide--protein
+                     glycotransferase OST4"
+     Region          1..33
+                     /region_name="Ost4"
+                     /note="Oligosaccaryltransferase; pfam10215"
+                     /db_xref="CDD:431142"
+     CDS             1..36
+                     /gene="OST4"
+                     /locus_tag="YDL232W"
+                     /coded_by="BK006938.2:38487..38597"
+                     /experiment="EXISTENCE:direct assay:GO:0005739
+                     mitochondrion [PMID:26928762]"
+                     /experiment="EXISTENCE:direct assay:GO:0030674
+                     protein-macromolecule adaptor activity [PMID:12810948]"
+                     /experiment="EXISTENCE:mutant phenotype:GO:0005789
+                     endoplasmic reticulum membrane [PMID:10677492]"
+                     /experiment="EXISTENCE:physical interaction:GO:0006487
+                     protein N-linked glycosylation [PMID:9405463]"
+                     /experiment="EXISTENCE:physical interaction:GO:0008250
+                     oligosaccharyltransferase complex [PMID:9405463]"
+                     /note="Subunit of the oligosaccharyltransferase complex of
+                     the ER lumen; complex catalyzes protein asparagine-linked
+                     glycosylation; type I membrane protein required for
+                     incorporation of Ost3p or Ost6p into the OST complex"
+                     /db_xref="SGD:S000002391"
+ORIGIN
+        1 misdeqlnsl aitfgivmmt liviyhavds tmspkn
+//

--- a/tests/test_module_parsers.py
+++ b/tests/test_module_parsers.py
@@ -441,3 +441,8 @@ def test_permissive_parser_malformed_LOCUS_line():
 
 def test_permissive_parser_base_count_misplaced():
     read(f"{test_files}/broken_genbank_files/base_count_misplaced.gb")
+
+
+def parse_protein_error():
+    with pytest.raises("AssertionError"):
+        parse("sequence-OST4-Genbank.gp")


### PR DESCRIPTION
There was code in th parser to pick up molecule type other than DNA. This is old cruft from the beginning of time when the parser was more general. I removed that and added an assertion to pick up if molecule type is "protein".
The fasta parser does not set molecule type, but it must be set to format genbank files.