### PR TITLE
Bug in crispr

### DIFF
--- a/src/pydna/crispr.py
+++ b/src/pydna/crispr.py
@@ -150,9 +150,9 @@ class cas9(_cas):
         matches_fwd = dseqrecord_finditer(self.compsite, query)
         matches_rev = dseqrecord_finditer(self.compsite, query.reverse_complement())
         for mobj in matches_fwd:
-            results.append((mobj.start() + 1 + self.fst5) % len(dna))
+            results.append((mobj.start() + self.fst5 + 1) % len(dna))
         for mobj in matches_rev:
-            results.append((mobj.start() + len(self.pam) + 1 - self.fst3) % len(dna))
+            results.append((len(dna) - (mobj.start() + self.fst5) + 1) % len(dna))
         return results
 
 

--- a/src/pydna/crispr.py
+++ b/src/pydna/crispr.py
@@ -3,6 +3,7 @@
 
 """
 Utilities for CRISPR/Cas target searching and protospacer extraction.
+
 """
 import re
 from abc import ABC
@@ -13,7 +14,7 @@ from typing import List
 from pydna.utils import rc
 from typing import TypeVar
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pydna.dseqrecord import Dseqrecord
 
 DseqrecordType = TypeVar("DseqrecordType", bound="Dseqrecord")
@@ -76,7 +77,7 @@ class _cas(ABC):
         The positions are the first base of the 3' fragment,
         i.e. the first base after the position the enzyme will cut.
         """
-        pass
+        raise NotImplementedError  # pragma: no cover
 
     def __repr__(self) -> str:
         """
@@ -87,12 +88,11 @@ class _cas(ABC):
         """
         return f"{type(self).__name__}({self.protospacer[:3]}..{self.protospacer[-3:]})"
 
-    @abstractmethod
     def __str__(self) -> str:
         """
-        Return a string representation of the guide and scaffold.
+        Return the guide RNA protospacer and scaffold as FASTA-like string.
         """
-        pass
+        return f">{type(self).__name__} protospacer scaffold\n{self.protospacer} {self.scaffold}"
 
 
 class cas9(_cas):
@@ -100,31 +100,28 @@ class cas9(_cas):
 
     .. code-block::
 
-            |----size----------|
 
-            ---protospacer------
-                            -fst3
-            fst5
-            |---------------|-
-                                PAM
+            fst5              --|fst3
+            |----------------
+                                 PAM
        5'-NNGGAAGAGTAATACACTA-AAANGGNN-3'
           ||||||||||||||||||| ||||||||
        3'-NNCCTTCTCATTATGTGAT-TTTNCCNN-5'
             ||||||||||||||||| |||
-         5'-GGAAGAGTAATACACTA-AAAg-u-a-a-g-g-3'  Scaffold
-            ---gRNA spacer---    u-a
-                                 u-a
-                                 u-a
-                                 u-a
-                                 a-u
-                                 g-u-g
-                                 a    a
-                                 g-c-a
-                                 c-g
-                                 u-a
-                                 a-u
-                                 g   a  tetraloop
-                                  a-a
+         5'-GGAAGAGTAATACACTA AAA-g-u-a-a-g-g-3'  Scaffold (lower case)
+            ---gRNA spacer------- u-a
+                                  u-a
+                                  u-a
+                                  u-a
+                                  a-u
+                                  g-u-g
+                                  a    a
+                                  g-c-a
+                                  c-g
+                                  u-a
+                                  a-u
+                                  g   a
+                                   a-a
     """
 
     scaffold: str = "GTTTTAGAGCTAGAAATAGCAAGTTAAAATAAGG"
@@ -145,25 +142,23 @@ class cas9(_cas):
         Returns:
             A list of cut site positions.
         """
+        if not hasattr(dna, "_data"):
+            raise TypeError
         dna = str(dna).upper()
         if linear:
-            dna = dna
+            d = dna
         else:
-            dna = dna + dna[1 : self.size]
+            d = dna + dna[: len(dna) - 1]
         results: List[int] = []
-        for mobj in self.compsite.finditer(dna):
+        for mobj in self.compsite.finditer(d):
             w, c = mobj.groups()
             if w:
-                results.append(mobj.start("watson") + 1 + self.fst5)
+                results.append((mobj.start("watson") + 1 + self.fst5) % len(dna))
             if c:
-                results.append(mobj.start("crick") + len(self.pam) + 1 - self.fst3)
+                results.append(
+                    (mobj.start("crick") + len(self.pam) + 1 - self.fst3) % len(dna)
+                )
         return results
-
-    def __str__(self) -> str:
-        """
-        Return the guide RNA protospacer and scaffold as FASTA-like string.
-        """
-        return f">{type(self).__name__} protospacer scaffold\n{self.protospacer} {self.scaffold}"
 
 
 def protospacer(guide_construct: DseqrecordType, cas: Type[_cas] = cas9) -> List[str]:

--- a/src/pydna/crispr.py
+++ b/src/pydna/crispr.py
@@ -1,49 +1,75 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2013-2023 by Björn Johansson.  All rights reserved.
-# This code is part of the Python-dna distribution and governed by its
-# license.  Please see the LICENSE.txt file that should have been included
-# as part of this package.
-"""Provides the Dseq class for handling double stranded DNA sequences.
-
-Dseq is a subclass of :class:`Bio.Seq.Seq`. The Dseq class
-is mostly useful as a part of the :class:`pydna.dseqrecord.Dseqrecord` class
-which can hold more meta data.
-
-The Dseq class support the notion of circular and linear DNA topology.
+"""
+Utilities for CRISPR/Cas target searching and protospacer extraction.
 """
 
 from abc import ABC, abstractmethod
 import re
+from typing import Any, List, Type
 from pydna.utils import rc
 
 
 class _cas(ABC):
-    scaffold = "ND"
-    pam = "ND"
-    size = 0
-    fst5 = 0
-    fst3 = 0
+    """
+    Abstract base class for CRISPR-associated nucleases.
+    pam, scaffold and cut location is set by a subclass
+    such as Cas9 below.
 
-    def __init__(self, protospacer):
-        self.protospacer = protospacer.upper()
+    The meaning of size, fst5 and fst3 are the same as for the restriciton
+    enzymes in the Biopython restriction module (Bio.Restriction).
+    """
+
+    scaffold: str = "ND"
+    pam: str = "ND"
+    size: int = 0
+    fst5: int = 0
+    fst3: int = 0
+
+    def __init__(self, protospacer: str) -> None:
+        """
+        Initialize the nuclease with a protospacer sequence.
+        The sequence is a string. Use the protospacer function
+        to extract a sequence from a Dseqrecord.
+
+        Args:
+            protospacer: Protospacer sequence used to build the search pattern.
+        """
+        self.protospacer: str = protospacer.upper()
         self.compsite = re.compile(
             f"(?=(?P<watson>{self.protospacer}{self.pam}))|(?=(?P<crick>{rc(self.pam)}{rc(self.protospacer)}))",
             re.UNICODE,
         )
 
     @abstractmethod
-    def search(self, dna, linear=True):
-        """To override in subclass."""
+    def search(self, dna: Any, linear: bool = True) -> List[int]:
+        """
+        Search for target sites in a DNA sequence.
+
+        Args:
+            dna: DNA sequence or sequence-like object.
+            linear: Whether the DNA is linear.
+
+        Returns:
+            A list of cut site positions.
+        """
         pass
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """
+        Return a compact representation of the Cas9+gRNA nuclease instance.
+
+        Returns:
+            String representation with abbreviated protospacer.
+        """
         return f"{type(self).__name__}({self.protospacer[:3]}..{self.protospacer[-3:]})"
 
     @abstractmethod
-    def __str__(self):
-        """To override in subclass."""
+    def __str__(self) -> str:
+        """
+        Return a string representation of the guide and scaffold.
+        """
         pass
 
 
@@ -56,44 +82,53 @@ class cas9(_cas):
 
             ---protospacer------
                             -fst3
-            fst5             |-|
-            |--------------|
+            fst5
+            |---------------|-
                                 PAM
-        5-NNGGAAGAGTAATACACTA-AAANGGNN-3
-        ||||||||||||||||||| ||||||||
-        3-NNCCTTCTCATTATGTGAT-TTTNCCNN-5
+       5'-NNGGAAGAGTAATACACTA-AAANGGNN-3'
+          ||||||||||||||||||| ||||||||
+       3'-NNCCTTCTCATTATGTGAT-TTTNCCNN-5'
             ||||||||||||||||| |||
-        5-GGAAGAGTAATACACTA-AAAg-u-a-a-g-g  Scaffold
+         5'-GGAAGAGTAATACACTA-AAAg-u-a-a-g-g-3'  Scaffold
             ---gRNA spacer---    u-a
-                                u-a
-                                u-a
-                                u-a
-                                a-u
-                                g-u-g
-                                a    a
-                                g-c-a
-                                c-g
-                                u-a
-                                a-u
-                                g   a  tetraloop
-                                a-a
+                                 u-a
+                                 u-a
+                                 u-a
+                                 a-u
+                                 g-u-g
+                                 a    a
+                                 g-c-a
+                                 c-g
+                                 u-a
+                                 a-u
+                                 g   a  tetraloop
+                                  a-a
     """
 
-    scaffold = "GTTTTAGAGCTAGAAATAGCAAGTTAAAATAAGG"
-    pam = ".GG"
-    size = 20
-    fst5 = 17
-    fst3 = -3
-    ovhg = fst5 - (size + fst3)
+    scaffold: str = "GTTTTAGAGCTAGAAATAGCAAGTTAAAATAAGG"
+    pam: str = ".GG"
+    size: int = 20
+    fst5: int = 17
+    fst3: int = -3
+    ovhg: int = fst5 - (size + fst3)
 
-    def search(self, dna, linear=True):
-        """docstring."""
+    def search(self, dna, linear: bool = True) -> List[int]:
+        """
+        Search for Cas9 target sites in a DNA sequence.
+
+        Args:
+            dna: string, Bio.Seq.Seq or pydna.dseq.Dseq
+            linear: Whether the DNA is linear or circular.
+
+        Returns:
+            A list of cut site positions.
+        """
         dna = str(dna).upper()
         if linear:
             dna = dna
         else:
             dna = dna + dna[1 : self.size]
-        results = []
+        results: List[int] = []
         for mobj in self.compsite.finditer(dna):
             w, c = mobj.groups()
             if w:
@@ -102,25 +137,39 @@ class cas9(_cas):
                 results.append(mobj.start("crick") + len(self.pam) + 1 - self.fst3)
         return results
 
-    def __str__(self):
-        """docstring."""
+    def __str__(self) -> str:
+        """
+        Return the guide RNA protospacer and scaffold as FASTA-like string.
+        """
         return f">{type(self).__name__} protospacer scaffold\n{self.protospacer} {self.scaffold}"
 
 
-def protospacer(guide_construct, cas=cas9):
-    """docstring."""
-    in_watson = [
-        mobj.group("ps")
-        for mobj in re.finditer(
-            f"(?P<ps>.{{{cas.size}}})(?:{cas.scaffold})",
-            str(guide_construct.seq).upper(),
+def protospacer(guide_construct, cas: Type[_cas] = cas9) -> List[str]:
+    """
+    Extract protospacer sequences from a guide construct. This can for example
+    be a plasmid containing the guide construct. This function returns a
+    list since a several protospacers can be present.
+
+    Args:
+        guide_construct: Sequence construct containing protospacer and scaffold.
+        cas: CRISPR nuclease class defining spacer size and scaffold.
+
+    Returns:
+        A list of protospacer sequences found in Watson and Crick orientations.
+    """
+    if guide_construct.circular:
+        total_length = cas.size + len(cas.scaffold)
+        guide_construct = guide_construct[:] + guide_construct[: total_length - 1]
+
+    result = []
+
+    for s in guide_construct.seq.watson.upper(), guide_construct.seq.crick.upper():
+        result.extend(
+            mobj.group("ps")
+            for mobj in re.finditer(
+                f"(?P<ps>.{{{cas.size}}})(?:{cas.scaffold})",
+                s,
+            )
         )
-    ]
-    in_crick = [
-        rc(mobj.group("ps"))
-        for mobj in re.finditer(
-            f"(?:{rc(cas.scaffold)})(?P<ps>.{{{cas.size}}})",
-            str(guide_construct.seq).upper(),
-        )
-    ]
-    return in_watson + in_crick
+
+    return result

--- a/src/pydna/crispr.py
+++ b/src/pydna/crispr.py
@@ -11,7 +11,6 @@ from abc import abstractmethod
 from typing import Type
 from typing import TYPE_CHECKING
 from typing import List
-from pydna.utils import rc
 from typing import TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -45,11 +44,10 @@ class _cas(ABC):
         Args:
             protospacer: Protospacer sequence used to build the search pattern.
         """
+        from pydna.sequence_regex import compute_regex_site
+
         self.protospacer: str = protospacer.upper()
-        self.compsite = re.compile(
-            f"(?=(?P<watson>{self.protospacer}{self.pam}))|(?=(?P<crick>{rc(self.pam)}{rc(self.protospacer)}))",
-            re.UNICODE,
-        )
+        self.compsite = compute_regex_site(f"{self.protospacer}{self.pam}")
 
     @abstractmethod
     def search(self, dna, linear: bool = True) -> List[int]:
@@ -142,22 +140,19 @@ class cas9(_cas):
         Returns:
             A list of cut site positions.
         """
+        from pydna.dseqrecord import Dseqrecord
+        from pydna.sequence_regex import dseqrecord_finditer
+
         if not hasattr(dna, "_data"):
             raise TypeError
-        dna = str(dna).upper()
-        if linear:
-            d = dna
-        else:
-            d = dna + dna[: len(dna) - 1]
         results: List[int] = []
-        for mobj in self.compsite.finditer(d):
-            w, c = mobj.groups()
-            if w:
-                results.append((mobj.start("watson") + 1 + self.fst5) % len(dna))
-            if c:
-                results.append(
-                    (mobj.start("crick") + len(self.pam) + 1 - self.fst3) % len(dna)
-                )
+        query = Dseqrecord(dna, circular=(not linear))
+        matches_fwd = dseqrecord_finditer(self.compsite, query)
+        matches_rev = dseqrecord_finditer(self.compsite, query.reverse_complement())
+        for mobj in matches_fwd:
+            results.append((mobj.start() + 1 + self.fst5) % len(dna))
+        for mobj in matches_rev:
+            results.append((mobj.start() + len(self.pam) + 1 - self.fst3) % len(dna))
         return results
 
 

--- a/src/pydna/crispr.py
+++ b/src/pydna/crispr.py
@@ -4,11 +4,19 @@
 """
 Utilities for CRISPR/Cas target searching and protospacer extraction.
 """
-
-from abc import ABC, abstractmethod
 import re
-from typing import Any, List, Type
+from abc import ABC
+from abc import abstractmethod
+from typing import Type
+from typing import TYPE_CHECKING
+from typing import List
 from pydna.utils import rc
+from typing import TypeVar
+
+if TYPE_CHECKING:
+    from pydna.dseqrecord import Dseqrecord
+
+DseqrecordType = TypeVar("DseqrecordType", bound="Dseqrecord")
 
 
 class _cas(ABC):
@@ -43,16 +51,30 @@ class _cas(ABC):
         )
 
     @abstractmethod
-    def search(self, dna: Any, linear: bool = True) -> List[int]:
-        """
-        Search for target sites in a DNA sequence.
+    def search(self, dna, linear: bool = True) -> List[int]:
+        """Return a list of cutting sites of the enzyme in the sequence.
 
-        Args:
-            dna: DNA sequence or sequence-like object.
-            linear: Whether the DNA is linear.
+        dna must be an instance of:
 
-        Returns:
-            A list of cut site positions.
+            - pydna.dseq.Dseq
+            - Bio.Seq.Seq
+            - Bio.Seq.MutableSeq
+
+        pydna.dseqrecord.Dseqrecord or Bio.SeqRecord.SeqRecord will not work.
+        This limitation is by design t omirror enzymes in the
+        Biopython Bio.Restriction class
+
+        The linear argument is laso there for compatibility with the
+        Biopython Bio.Restriction class.
+
+        An important caveat is that search ignores the circular property of
+        pydna.dseq.Dseq.
+
+        If linear is False, the restriction sites that span over the boundaries
+        will be included.
+
+        The positions are the first base of the 3' fragment,
+        i.e. the first base after the position the enzyme will cut.
         """
         pass
 
@@ -144,7 +166,7 @@ class cas9(_cas):
         return f">{type(self).__name__} protospacer scaffold\n{self.protospacer} {self.scaffold}"
 
 
-def protospacer(guide_construct, cas: Type[_cas] = cas9) -> List[str]:
+def protospacer(guide_construct: DseqrecordType, cas: Type[_cas] = cas9) -> List[str]:
     """
     Extract protospacer sequences from a guide construct. This can for example
     be a plasmid containing the guide construct. This function returns a

--- a/tests/test_module_crispr.py
+++ b/tests/test_module_crispr.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import pytest
+from Bio.Restriction import BamHI
 from pydna.dseqrecord import Dseqrecord
 from pydna.dseq import Dseq
 from Bio.Restriction import SapI
@@ -8,6 +10,10 @@ from pydna.parsers import parse_primers
 from pydna.crispr import cas9, protospacer
 from pydna.assembly import Assembly
 from textwrap import dedent
+from Bio.Seq import Seq
+from Bio.Seq import MutableSeq
+from Bio.SeqRecord import SeqRecord
+from Bio.Restriction import FormattedSeq
 
 
 def test_crispr():
@@ -27,15 +33,15 @@ def test_crispr():
     )
 
     sgr_text = "GTTACTTTACCCGACGTCCCgttttagagctagaaatagcaagttaaaataagg"
-    target = "GTTACTTTACCCGACGTCCCaGG"
+    target_string = "GTTACTTTACCCGACGTCCCaGG"
 
     for _sg, _tgt in [
-        (sgr_text, target),
-        (sgr_text.upper(), target.lower()),
-        (sgr_text.lower(), target.upper()),
+        (sgr_text, target_string),
+        (sgr_text.upper(), target_string.lower()),
+        (sgr_text.lower(), target_string.upper()),
     ]:
         containing_sgRNA = Dseqrecord(sgr_text)
-        target = Dseqrecord(target)
+        target = Dseqrecord(target_string)
 
         assert [
             f.seq
@@ -59,9 +65,48 @@ def test_crispr():
             a.rc(),
         ]
 
-    assert target.cut(cas9("GTTACTTTACCCGACGTCCC")) == target.cut(
-        cas9("GTTACTTTACCCGACGTCCC".lower())
+    c9 = cas9("GTTACTTTACCCGACGTCCC")
+
+    assert (
+        str(c9)
+        == ">cas9 protospacer scaffold\nGTTACTTTACCCGACGTCCC GTTTTAGAGCTAGAAATAGCAAGTTAAAATAAGG"
     )
+
+    assert target.cut(c9) == target.cut(cas9("GTTACTTTACCCGACGTCCC".lower()))
+
+    with pytest.raises(TypeError):
+        BamHI.search("GGATCC")
+
+    assert BamHI.search(Seq("GGATCC")) == [2]
+    assert BamHI.search(MutableSeq("GGATCC")) == [2]
+    assert BamHI.search(Dseq("GGATCC")) == [2]
+    with pytest.raises(TypeError):
+        assert BamHI.search(SeqRecord("GGATCC")) == [2]
+    with pytest.raises(TypeError):
+        assert BamHI.search(FormattedSeq("GGATCC")) == [2]
+    with pytest.raises(TypeError):
+        assert BamHI.search(Dseqrecord("GGATCC")) == [2]
+    assert BamHI.search(Seq("GATCCG"), linear=False) == [1]
+    assert BamHI.search(MutableSeq("GATCCG"), linear=False) == [1]
+    assert BamHI.search(Dseq("GATCCG"), linear=False) == [1]
+    assert BamHI.search(Dseq("GATCCG", circular=True), linear=True) == []
+
+    with pytest.raises(TypeError):
+        c9.search(target_string)
+    assert c9.search(Seq(target_string)) == [18]
+    assert c9.search(MutableSeq(target_string)) == [18]
+    assert c9.search(Dseq(target_string)) == [18]
+    with pytest.raises(TypeError):
+        assert c9.search(SeqRecord(target_string)) == [18]
+    with pytest.raises(TypeError):
+        assert c9.search(FormattedSeq(target_string)) == [18]
+    with pytest.raises(TypeError):
+        assert c9.search(Dseqrecord(target_string)) == [18]
+    rotated_target_string = target_string[1:] + target_string[0]
+    assert c9.search(Seq(rotated_target_string), linear=False) == [17]
+    assert c9.search(MutableSeq(rotated_target_string), linear=False) == [17]
+    assert c9.search(Dseq(rotated_target_string), linear=False) == [17]
+    assert c9.search(Dseq("ggat", circular=True), linear=True) == []
 
 
 def test_crispr_torulaspora():

--- a/tests/test_module_crispr.py
+++ b/tests/test_module_crispr.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from pydna.dseqrecord import Dseqrecord
+from pydna.dseq import Dseq
+from Bio.Restriction import SapI
+from pydna.parsers import parse_primers
+from pydna.crispr import cas9, protospacer
+from pydna.assembly import Assembly
+from textwrap import dedent
+
 
 def test_crispr():
-    from pydna.crispr import cas9, protospacer
-    from pydna.dseqrecord import Dseqrecord
-    from pydna.dseq import Dseq
 
     a = Dseq.from_representation(
         """\
@@ -57,3 +62,235 @@ def test_crispr():
     assert target.cut(cas9("GTTACTTTACCCGACGTCCC")) == target.cut(
         cas9("GTTACTTTACCCGACGTCCC".lower())
     )
+
+
+def test_crispr_torulaspora():
+    """
+    1. Two single stranded oligos are annealed in-vitro
+    2. They form a 26 bp dsDNA fragment with 5' overhangs
+    3. This fragment is cloned in plasmid pTgCRISPRplanB cut with SapI (2 cuts)
+       The resulting pTgCRISPR_guide has a complete guide sequrnce with scaffold
+    4. The pTgCRISPR_guide is used to instantiate a Cas9 object (gr)
+    5. torulaspora_locus is cut into two fragments (before & after)
+    6. before, repair_template, after are assembled into a new deletion locus.
+
+    Lombardi, L., Oliveira-Pacheco, J., & Butler, G. (2019).
+    Plasmid-Based CRISPR-Cas9 Gene Editing in Multiple Candida
+    Species. mSphere, 4(2), e00125-19.
+    https://doi.org/10.1128/mSphere.00125-19
+
+    """
+
+    guides = """
+    >NewGuide_Fw
+    CCAAAGGCTGCTGCTTATGCCAG
+
+    >NewGuide_Rv
+    AACCTGGCATAAGCAGCAGCCTT
+    """
+    watson, crick = parse_primers(guides)
+
+    guide_insert = Dseqrecord(Dseq(str(watson.seq), str(crick.seq)))
+
+    assert repr(guide_insert.seq) == dedent(
+        """\
+                                            Dseq(-26)
+                                            CCAAAGGCTGCTGCTTATGCCAG
+                                               TTCCGACGACGAATACGGTCCAA"""
+    )
+
+    # This is only a partial sequence of the plasmid
+    pTgCRISPRplanB = Dseqrecord(
+        "gggcgtgtggcgtagttggtagcgcgttcccttagcatgg"
+        "gaaaggtcatgagttcgattcttatctcgtccaggaagag"
+        "ctcgcgagctcttccgttttagagctagaaatagcaagtt"
+        "aaaataaggctagtccgttatcaacttgaaaaagtggcac"
+        "cgagtcggtgc",
+        name="plasmid",
+        circular=True,
+    )
+
+    stuffer, linear_plasmid = pTgCRISPRplanB.cut(SapI)
+
+    assert repr(linear_plasmid.seq) == dedent(
+        """\
+                                              Dseq(-149)
+                                              gttttag..tcgt
+                                                 aatc..agcaggt"""
+    )
+
+    pTgCRISPR_guide = (linear_plasmid + guide_insert).looped()
+
+    gr = cas9(protospacer(pTgCRISPR_guide).pop())
+
+    assert protospacer(pTgCRISPR_guide) == protospacer(pTgCRISPR_guide.rc())
+
+    assert repr(gr) == "cas9(AAG..CAG)"
+
+    repair_template = Dseqrecord(
+        "aggaggcttacaacgaatcataatcccacgactactc"
+        "tactttttacatagatgtaatatctccttatcgcact"
+        "gtcgtcctcttgctgtttccgtaagcgatgagcctct"
+        "cgcccaccttgtcgtcctgttggccggacccttgctt"
+        "gtatttcaacagcaaactgcgccggactcttcctgat"
+        "atgtacgtcgccgctctgttgtgacgtctaatagtct"
+        "gggggtgtgattggttgatgactagacctccggaata"
+        "acttcgaagcatttcttttaagagatggtctgctcat"
+        "tcgcagaaggagtgtcattgagacgtttagctggtcg"
+        "acgtcgagctatataaacgtgcgggtggtacaagatg"
+        "aacattttctagattcagttcgagagcagcaacattc"
+        "ttttaagctcacaaatgcatgctcacactcggtcata"
+        "atgtaatgaaccaacctacctatttttttatcgttta"
+        "tttaccaattacgttcggaaaaacttgttgttccgag"
+        "ggacagtttgctgccagcaaccggaaaaactttgacc"
+        "cgagggacaaggctgaagctcgaaatgccaaggctgt"
+        "cgtcgagctgggcaaagaaaggtgcgatatttcaaat"
+        "cacttattctacttttcttgttgttttagcacgttgg"
+        "agcctaaatcttggaagcttgtaaactcaaaatcgca"
+        "agatctagtaggaatattcggaaatttcgagttggag"
+        "gttgtttctccccgctgaaattcgtagtctcttgtta"
+        "ttcaggtctctcgtatgggttcgctgctggtatggtc"
+        "ccgatcccaccttcttagtagactttggctggtagtt"
+        "ctcgggaaaacttggttgcttaggaaaagaaagtttt"
+        "tccgggccctcacaaggccctgcagaa",
+        name="repair_template",
+    )
+
+    torulaspora_locus = Dseqrecord(
+        "AGTCCGATGTCATTACTGAGGAGGCTTACAACGAAT"
+        "CATAATCCCACGACTACTCTACTTTTTACATAGATG"
+        "TAATATCTCCTTATCGCACTGTCGTCCTCTTGCTGT"
+        "TTCCGTAAGCGATGAGCCTCTCGCCCACCTTGTCGT"
+        "CCTGTTGGCCGGACCCTTGCTTGTATTTCAACAGCA"
+        "AACTGCGCCGGACTCTTCCTGATATGTACGTCGCCG"
+        "CTCTGTTGTGACGTCTAATAGTCTGGGGGTGTGATT"
+        "GGTTGATGACTAGACCTCCGGAATAACTTCGAAGCA"
+        "TTTCTTTTAAGAGATGGTCTGCTCATTCGCAGAAGG"
+        "AGTGTCATTGAGACGTTTAGCTGGTCGACGTCGAGC"
+        "TATATAAACGTGCGGGTGGTACAAGATGAACATTTT"
+        "CTAGATTCAGTTCGAGAGCAGCAACATTCTTTTAAG"
+        "CATGTCGGAAGGTCAAAATATAGCTGTTGCGACAAG"
+        "CACtaattcaaattcaaattctaaCTCGACGTCCAT"
+        "CGAGAAGACAGATAAGGCTGCTGCTTATGCCAGTGG"
+        "TGGGACAGCTGCTGACGGGGCTGATTTGGAGCAGTT"
+        "TAGAAGTCATGATGAAGGTGAGAAGGATGAGATGAC"
+        "TCAGCTGGTCCGCGATGCGGACCAGCAGGCTGCTAC"
+        "CATGAAGAAGTCTGACCTGATGTTTGTTTCGTTATG"
+        "TTGTGTTATGGTTGCATTTGGGGGGTTTGTATTTGG"
+        "TTGGGATACTGGTACTATATCTGGGTTTGTTAACCA"
+        "GACCGACTGGATTAGACGGTTTGGGTCTTATAACCA"
+        "AAATACTGGTCAGTACTACTTGTCTGATGTGCGTAC"
+        "AGGTTTGCTGGTTTCGATCTTCAATATTGGGTGTGC"
+        "CATTGGTGGTATTGTGCTCAGTAAAGCCGGTGACTT"
+        "GTATGGTAGACGTTTGGGATTGGTTTTCGTTGTGGT"
+        "CATTTATACCGTTGGTATATTAATTCAAATCTGTTC"
+        "TTTCGATAAGTGGTACCAGTACTTTATTGGAAGGAT"
+        "TATATCTGGTTTAGGTGTAGGTGGTATTACCGTTAT"
+        "GTCGCCCATGTTGATATCTGAGGTGGCCCCCAAGCA"
+        "AACTAGAGGTACCCTTATTTCGTGCTACCAGTTGAT"
+        "GATCACTGGTGGTATCTTTTTAGGTTACTGTACCAA"
+        "TTTTGGTACCAAGCAGTATGATGATTCTACGCAATG"
+        "GAGAGTACCACTGGGTCTGTGCTTTGCCTGGGCTAT"
+        "GTTTATGATCGGTGGTATGTTGTTCGTGCCAGAATC"
+        "CCCACGTTACTTAGTAGAAGTTGGTAAGATGGAAGA"
+        "GGCAAGACGTTCGTTGGCTAGAGCCAATAGGTGTCC"
+        "CACAGAATCTCCATTGGTAACTTTGGAATTAGAAAA"
+        "TTTCCAGGCTTCCGTAGAGGCTGAAAAGGTCGCGGG"
+        "TAGCGCCAGTTGGTCCGAATTGATCACTGGTAAACC"
+        "TGCTATCTTCAAGCGTACCCTGATGGGTGTTATGAT"
+        "CCAGTCCTTGCAGCAATTGACTGGTGATAACTACTT"
+        "CTTTTACTACGGTACTACGATTTTCAGAGCAGTCGG"
+        "GTTGGAGGATTCGTTCGAGACTTCGATCGTTCTCGG"
+        "TGTAGTCAACTTTGCCTCTACATTCCTTGCATTGTA"
+        "CACTGTGGATCACTTTGGTCGTCGTAAATGTCTACT"
+        "ATGGGGTTGTATTGGTATGGTCTGTTGTTATGTCGT"
+        "TTATGCATCTGTCGGTGTCACTAGATTATGGCCAGA"
+        "TGGACAAGATCAACCATCTTCCAAGGGTGCTGGTAA"
+        "CTGTATGATTGTTTTCGCatgtttcttcatcttctg"
+        "ttTCGCTACCACTTGGGCTCCAATTGCATACGTTAT"
+        "CATCTCTGAATCTTTCCCATTGAGAATCAAGTCCAA"
+        "GGCTATGTCCATTGCAAGTGCTTCTAACTGGCTATG"
+        "GGGTTTCTTGATTGGTTTCTTCACTCCTTTCATCAC"
+        "ATCCGCGATCAATTTCTATTACGGGTACGTGTTTAT"
+        "GGGCTGTATGGTGTTTGCATTTTTCtatgtcttctt"
+        "cttcgtcccAGAGACCAAAGGtttgactttggaaga"
+        "agtgaaCATCATGTATGAAGAACGTGTCTTGCCTTG"
+        "GAAGTCAGCATCTTGGTTACCTCCACACAGAAGGGG"
+        "AGCCGACTTTGACGCAGATGCCTACACTAGGGACGA"
+        "CCTCCCCTTCTACAAAAGAATGCTGCGTAGAAATTA"
+        "ATCACAAATGCATGCTCACACTCGGTCATAATGTAA"
+        "TGAACCAACCTACCTATTTTTTTATCGTTTATTTAC"
+        "CAATTACGTTCGGAAAAACTTGTTGTTCCGAGGGAC"
+        "AGTTTGCTGCCAGCAACCGGAAAAACTTTGACCCGA"
+        "GGGACAAGGCTGAAGCTCGAAATGCCAAGGCTGTCG"
+        "TCGAGCTGGGCAAAGAAAGGTGCGatatttcaaatc"
+        "acttaTTCTacttttcttgttgtttTAGCACGTTGG"
+        "AGCCTAAATCTTGGAAGCTTGTAAACTCAAAATCGC"
+        "AAGATCTAGTAGGAATATTCGGAAATTTCGAGTTGG"
+        "AGGTTGTTTCTCCCCGCTGAAATTCGTAGTCTCTTG"
+        "TTATTCAGGTCTCTCGTATGGGTTCGCTGCTGGTAT"
+        "GGTCCCGATCCCACCTTCTTAGTAGACTTTGGCTGG"
+        "TAGTTCTCGGGAAAACTTGGTTGCTTAGGAAAAGAA"
+        "AGTTTTTCCGGGCCCTCACAAGGCCCTGCAGAAGAG"
+        "TTTT"
+    )
+
+    before, after = torulaspora_locus.cut(gr)
+
+    before.name = "before"
+    after.name = "after"
+
+    assert len(before) == 534
+    assert len(after) == 2170
+
+    asm = Assembly((before, repair_template, after))
+
+    deleted = asm.assemble_linear().pop()
+
+    expected = (
+        "before|415\n"
+        "       \\/\n"
+        "       /\\\n"
+        "       415|repair_template|500\n"
+        "                           \\/\n"
+        "                           /\\\n"
+        "                           500|after"
+    )
+
+    assert deleted.figure() == expected
+
+    assert repr(deleted) == "Contig(-940)"
+
+    assert deleted.seguid() == "ldseguid=HxGfGzivCuau8hBCOTAlzJq_FRo"
+
+    final_deletion = Dseqrecord(
+        "AGTCCGATGTCATTACTGaggaggcttacaacgaat"
+        "cataatcccacgactactctactttttacatagatg"
+        "taatatctccttatcgcactgtcgtcctcttgctgt"
+        "ttccgtaagcgatgagcctctcgcccaccttgtcgt"
+        "cctgttggccggacccttgcttgtatttcaacagca"
+        "aactgcgccggactcttcctgatatgtacgtcgccg"
+        "ctctgttgtgacgtctaatagtctgggggtgtgatt"
+        "ggttgatgactagacctccggaataacttcgaagca"
+        "tttcttttaagagatggtctgctcattcgcagaagg"
+        "agtgtcattgagacgtttagctggtcgacgtcgagc"
+        "tatataaacgtgcgggtggtacaagatgaacatttt"
+        "ctagattcagttcgagagcagcaacattcttttaag"
+        "cTCACAAATGCATGCTCACACTCGGTCATAATGTAA"
+        "TGAACCAACCTACCTATTTTTTTATCGTTTATTTAC"
+        "CAATTACGTTCGGAAAAACTTGTTGTTCCGAGGGAC"
+        "AGTTTGCTGCCAGCAACCGGAAAAACTTTGACCCGA"
+        "GGGACAAGGCTGAAGCTCGAAATGCCAAGGCTGTCG"
+        "TCGAGCTGGGCAAAGAAAGGTGCGATATTTCAAATC"
+        "ACTTATTCTACTTTTCTTGTTGTTTTAGCACGTTGG"
+        "AGCCTAAATCTTGGAAGCTTGTAAACTCAAAATCGC"
+        "AAGATCTAGTAGGAATATTCGGAAATTTCGAGTTGG"
+        "AGGTTGTTTCTCCCCGCTGAAATTCGTAGTCTCTTG"
+        "TTATTCAGGTCTCTCGTATGGGTTCGCTGCTGGTAT"
+        "GGTCCCGATCCCACCTTCTTAGTAGACTTTGGCTGG"
+        "TAGTTCTCGGGAAAACTTGGTTGCTTAGGAAAAGAA"
+        "AGTTTTTCCGGGCCCTCACAAGGCCCTGCAGAAGAG"
+        "TTTT"
+    )
+
+    assert deleted.seq == final_deletion.seq

--- a/tests/test_module_crispr.py
+++ b/tests/test_module_crispr.py
@@ -339,3 +339,17 @@ def test_crispr_torulaspora():
     )
 
     assert deleted.seq == final_deletion.seq
+
+
+def test_cut():
+    seq = Dseqrecord("ttCATTACTGTTTGCATTGAACaGGCCC", circular=True)
+    enz = cas9("CATTACTGTTTGCATTGAAC")
+    expected = set([Dseq("AACAGGCCCTTCATTACTGTTTGCATTG").seguid()])
+
+    for shift in range(len(seq)):
+        seq_shifted = seq.shifted(shift)
+        for rc in [False, True]:
+            seq_shifted_rc = seq_shifted.reverse_complement() if rc else seq_shifted
+            products = seq_shifted_rc.cut(enz)
+            seguids = set(f.seq.seguid() for f in products)
+            assert seguids == expected


### PR DESCRIPTION
The protospacer function can now can now extract from a circular sequence even if the guide RNA loops the origin. More tests and higher coverage. Bugfix for the cas9.search method. Moved the __str__ to the _cas base class. 