### PR TITLE
Simplified how the Dseqrecord __add__ handles features.

### DIFF
--- a/docs/notebooks/Example_Restriction.ipynb
+++ b/docs/notebooks/Example_Restriction.ipynb
@@ -585,8 +585,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ACCATGTCGACATGCAAACAGTAATGATGGA , Tm:  57.24061148156318\n",
-      "GGCGCGCCATTAAAAGCCTTCTTCTCCC , Tm:  56.64459495003314\n"
+      "ACCATGTCGACATGCAAACAGTAATGATGGA , Tm:  58.57602926085667\n",
+      "GGCGCGCCATTAAAAGCCTTCTTCTCCC , Tm:  58.36015907667411\n"
      ]
     }
    ],
@@ -603,8 +603,8 @@
     "amplicon = primer_design(pombe_chromosome_I[min(gene):max(gene)], target_tm=55)\n",
     "\n",
     "fwd_align, rvs_align = amplicon.primers()\n",
-    "fwd_primer_ase1 = Dseqrecord(\"ACCATGTCGAC\") + fwd_align # Adding a SalI cut site\n",
-    "rvs_primer_ase1 = Dseqrecord(\"GGCGCGCCAT\") + rvs_align # Adding a AscI cut site\n",
+    "fwd_primer_ase1 = \"ACCATGTCGAC\" + fwd_align # Adding a SalI cut site\n",
+    "rvs_primer_ase1 = \"GGCGCGCCAT\" + rvs_align # Adding a AscI cut site\n",
     "\n",
     "# Printing out the primers\n",
     "\n",
@@ -622,13 +622,13 @@
      "output_type": "stream",
      "text": [
       "LOCUS       2263bp_PCR_prod         2263 bp    DNA     linear   UNK 01-JAN-1980\n",
-      "DEFINITION  pcr_product_description_description.\n",
+      "DEFINITION  pcr_product_f2242 CU329670.1_r2242 CU329670.1.\n",
       "ACCESSION   2263bp\n",
       "VERSION     2263bp\n",
       "DBLINK      BioProject: PRJNA13836\n",
       "            BioSample: SAMEA3138176\n",
       "KEYWORDS    .\n",
-      "SOURCE      .\n",
+      "SOURCE      \n",
       "  ORGANISM  .\n",
       "            .\n",
       "FEATURES             Location/Qualifiers\n",
@@ -653,13 +653,13 @@
       "                     NVPLSPPKQRVVNEHALNIMSEKLQRTNLKEQTPEMDIENSSQNLPFSPMKISPIRASP\n",
       "                     VKTIPSSPSPTTNIFSAPLNNITNCTPMEDEWGEEGF\"\n",
       "     primer_bind     12..31\n",
-      "                     /label=\"name\"\n",
+      "                     /label=\"f2242\"\n",
       "                     /PCR_conditions=\"primer\n",
       "                     sequence:ACCATGTCGACATGCAAACAGTAATGATGGA\"\n",
       "                     /ApEinfo_fwdcolor=\"#baffa3\"\n",
       "                     /ApEinfo_revcolor=\"#ffbaba\"\n",
       "     primer_bind     complement(2236..2254)\n",
-      "                     /label=\"name\"\n",
+      "                     /label=\"r2242\"\n",
       "                     /PCR_conditions=\"primer\n",
       "                     sequence:GGCGCGCCATTAAAAGCCTTCTTCTCCC\"\n",
       "                     /ApEinfo_fwdcolor=\"#baffa3\"\n",
@@ -759,7 +759,7 @@
       "ACCESSION   id\n",
       "VERSION     id\n",
       "KEYWORDS    .\n",
-      "SOURCE      .\n",
+      "SOURCE      \n",
       "  ORGANISM  .\n",
       "            .\n",
       "FEATURES             Location/Qualifiers\n",
@@ -861,13 +861,13 @@
       "                     NVPLSPPKQRVVNEHALNIMSEKLQRTNLKEQTPEMDIENSSQNLPFSPMKISPIRASP\n",
       "                     VKTIPSSPSPTTNIFSAPLNNITNCTPMEDEWGEEGF\"\n",
       "     primer_bind     3918..3937\n",
-      "                     /label=\"name\"\n",
+      "                     /label=\"f2242\"\n",
       "                     /PCR_conditions=\"primer\n",
       "                     sequence:ACCATGTCGACATGCAAACAGTAATGATGGA\"\n",
       "                     /ApEinfo_fwdcolor=\"#baffa3\"\n",
       "                     /ApEinfo_revcolor=\"#ffbaba\"\n",
       "     primer_bind     complement(6142..6160)\n",
-      "                     /label=\"name\"\n",
+      "                     /label=\"r2242\"\n",
       "                     /PCR_conditions=\"primer\n",
       "                     sequence:GGCGCGCCATTAAAAGCCTTCTTCTCCC\"\n",
       "                     /ApEinfo_fwdcolor=\"#baffa3\"\n",
@@ -994,9 +994,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python (pydna312_bp185)",
    "language": "python",
-   "name": "python3"
+   "name": "pydna312_bp185"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1008,9 +1008,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/notebooks/Example_Restriction.ipynb
+++ b/docs/notebooks/Example_Restriction.ipynb
@@ -994,9 +994,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (pydna312_bp185)",
+   "display_name": ".venv",
    "language": "python",
-   "name": "pydna312_bp185"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -812,7 +812,8 @@ class Dseqrecord(SeqRecord):
 
     def __add__(self, other):
         if hasattr(other, "seq") and hasattr(other.seq, "watson"):
-            # other is likely another Dseqrecord
+            # other is likely another Dseqrecord with a Dseq object
+            # deepcopy is necessary since we will change other's features
             other = copy.deepcopy(other)
             newseq = self.seq + other.seq
             # offset is the length of the self Dseq object added to the
@@ -822,12 +823,13 @@ class Dseqrecord(SeqRecord):
             for f in other.features:
                 # adding an integer to a feature location shifts it.
                 f.location = f.location + offset
-            answer = Dseqrecord(SeqRecord.__add__(self, other))
-            answer.n = min(self.n, other.n)
-            answer.seq = newseq
         else:
-            answer = Dseqrecord(SeqRecord.__add__(self, Dseqrecord(other)))
-            answer.n = self.n
+            # If other is not a Dseqrecord with a Dseq object, the Dseq class
+            # handles the result of adding for consistency.
+            newseq = self.seq + other
+        answer = Dseqrecord(SeqRecord.__add__(self, other))
+        answer.n = min(self.n, getattr(other, "n", self.n))
+        answer.seq = newseq
         return answer
 
     def __mul__(self, number):

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -812,19 +812,19 @@ class Dseqrecord(SeqRecord):
 
     def __add__(self, other):
         if hasattr(other, "seq") and hasattr(other.seq, "watson"):
+            # other is likely another Dseqrecord
             other = copy.deepcopy(other)
-            other_five_prime = other.seq.five_prime_end()
-            if other_five_prime[0] == "5'":
-                # add other.seq.ovhg
-                for f in other.features:
-                    f.location = f.location + other.seq.ovhg
-            elif other_five_prime[0] == "3'":
-                # subtract other.seq.ovhg (sign change)
-                for f in other.features:
-                    f.location = f.location + (-other.seq.ovhg)
-
+            newseq = self.seq + other.seq
+            # offset is the length of the self Dseq object added to the
+            # other Dseq object minus the sum of each length
+            # offset is <= 0
+            offset = len(newseq) - (len(self) + len(other))
+            for f in other.features:
+                # adding an integer to a feature location shifts it.
+                f.location = f.location + offset
             answer = Dseqrecord(SeqRecord.__add__(self, other))
             answer.n = min(self.n, other.n)
+            answer.seq = newseq
         else:
             answer = Dseqrecord(SeqRecord.__add__(self, Dseqrecord(other)))
             answer.n = self.n


### PR DESCRIPTION
Now it simply observes the difference between the length of the separate parts and the ligated fragment without calling seq object methods. 

Also only one loop to push features.