### PR TITLE
Primer screen supporting circular templates

### DIFF
--- a/src/pydna/primer_screen.py
+++ b/src/pydna/primer_screen.py
@@ -39,9 +39,7 @@ This module uses `pyahocorasick`:
     PyPI: https://pypi.python.org/pypi/pyahocorasick
 """
 
-
-# TODO: circular templates
-
+from operator import attrgetter
 from itertools import product
 from itertools import combinations
 from itertools import pairwise
@@ -324,16 +322,20 @@ def forward_primers(
         values are lists with primer locations.
 
     """
+    assert primer_list, "primer_list must not be empty."
 
     # if no automaton is given, we make one.
     automaton = automaton or make_automaton(primer_list, limit=limit)
 
     # The limit is taken from automaton stats.
+    # If the automaton is given, the limit argument will be ignored.
     limit = automaton.get_stats()["longest_word"]
 
     # A defaultdict of lists is used to collect primer locations since
     # different primers can anneal in the same place.
     fps = defaultdict(list)
+
+    seq = seq[:] + seq[: limit - 1] if seq.circular else seq
 
     for end_index, ids in automaton.iter(str(seq.seq).upper()):
         for i in ids:
@@ -344,7 +346,7 @@ def forward_primers(
 
 def reverse_primers(
     seq: Dseqrecord,
-    primer_list: list[Primer] | tuple[Primer],
+    primer_list: Sequence[Primer | None],
     limit: int = 16,
     automaton: ahocorasick.Automaton = None,
 ) -> dict[int, list[int]]:
@@ -403,6 +405,8 @@ def reverse_primers(
         values are lists with primer locations.
 
     """
+    assert primer_list, "primer_list must not be empty."
+
     # if no automaton is given, we make one.
     automaton = automaton or make_automaton(primer_list, limit=limit)
 
@@ -413,6 +417,7 @@ def reverse_primers(
     # A defaultdict of lists is used to collect primer locations since
     # different primers can anneal in the same place.
     rps = defaultdict(list)
+    seq = seq[:] + seq[: limit - 1] if seq.circular else seq
     ln = len(seq)
 
     # We use the reverse complement of the sequence instead of taking the
@@ -426,7 +431,7 @@ def reverse_primers(
 
 def primer_pairs(
     seq: Dseqrecord,
-    primer_list: list[Primer] | tuple[Primer],
+    primer_list: Sequence[Primer | None],
     short: int = 500,
     long: int = 2000,
     limit: int = 16,
@@ -483,24 +488,26 @@ def primer_pairs(
         List of tuples (index_fp, position_fp, index_rp, position_rp, size)
 
     """
+    assert primer_list, "primer_list must not be empty."
+
+    # if no automaton is given, we make one.
     automaton = automaton or make_automaton(primer_list, limit=limit)
+
+    # The limit is taken from automaton stats.
+    # If the automaton is given, the limit argument will be ignored.
     limit = automaton.get_stats()["longest_word"]
 
     # Unique forward primers are collected
     fps = {
         fp: pos[0]
-        for fp, pos in forward_primers(
-            seq, primer_list, limit=limit, automaton=automaton
-        ).items()
+        for fp, pos in forward_primers(seq, primer_list, automaton=automaton).items()
         if len(pos) == 1
     }
 
     # Unique reverse primers are collected
     rps = {
         rp: pos[0]
-        for rp, pos in reverse_primers(
-            seq, primer_list, limit=limit, automaton=automaton
-        ).items()
+        for rp, pos in reverse_primers(seq, primer_list, automaton=automaton).items()
         if len(pos) == 1
     }
     products = []
@@ -512,13 +519,30 @@ def primer_pairs(
             # If the size falls within long and short, the data is kept.
             if short <= size <= long and fposition <= rposition:
                 products.append(amplicon_tuple(fp, rp, fposition, rposition, size))
+    # if sequence is circular we also look at forward primers that sits after the
+    # reverse primer and amplify across the origin
+    if seq.circular:
+        ln = len(seq)
+        for fp, fposition in fps.items():
+            for rp, rposition in rps.items():
+                if fposition > rposition:
+                    size = (
+                        len(primer_list[fp])
+                        + rposition
+                        + (ln - fposition)
+                        + len(primer_list[rp])
+                    )
+                    if short <= size <= long:
+                        products.append(
+                            amplicon_tuple(fp, rp, fposition, rposition, size)
+                        )
     return products
 
 
 def flanking_primer_pairs(
     seq: Dseqrecord,
-    primer_list: list[Primer] | tuple[Primer],
-    target: tuple[int, int],
+    primer_list: Sequence[Primer | None],
+    target: tuple[int, int] = (None, None),
     limit: int = 16,
     automaton: ahocorasick.Automaton = None,
 ) -> list[amplicon_tuple[int, int, int, int, int]]:
@@ -561,11 +585,10 @@ def flanking_primer_pairs(
 
     """
 
-    automaton = automaton or make_automaton(primer_list, limit=limit)
-    limit = automaton.get_stats()["longest_word"]
-
     begin, end = target
 
+    assert begin is not None, "begin has to be set."
+    assert end is not None, "end has to be set."
     assert begin < end, "begin has to be smaller than end."
 
     amplicons = primer_pairs(
@@ -579,15 +602,22 @@ def flanking_primer_pairs(
     products = []
 
     for amplicon in amplicons:
-        if amplicon.fposition >= begin and end <= amplicon.rposition:
+        if amplicon.fposition <= begin and end <= amplicon.rposition:
             products.append(amplicon)
+    if seq.circular:
+        for amplicon in amplicons:
+            if amplicon.fposition > amplicon.rposition:
+                if (amplicon.fposition <= begin or begin <= amplicon.rposition) and (
+                    amplicon.fposition <= end or end <= amplicon.rposition
+                ):
+                    products.append(amplicon)
 
-    return products[::-1]
+    return sorted(products, key=attrgetter("size"))  # results sorted by size
 
 
 def diff_primer_pairs(
     sequences: list[Dseqrecord] | tuple[Dseqrecord],
-    primer_list: list[Primer] | tuple[Primer],
+    primer_list: Sequence[Primer | None],
     short: int = 500,
     long: int = 1500,
     limit: int = 16,
@@ -703,7 +733,7 @@ def diff_primer_pairs(
 
 def diff_primer_triplets(
     sequences: list[Dseqrecord] | tuple[Dseqrecord],
-    primer_list: list[Primer] | tuple[Primer],
+    primer_list: Sequence[Primer | None],
     limit: int = 16,
     short: int = 500,
     long: int = 1500,

--- a/src/pydna/primer_screen.py
+++ b/src/pydna/primer_screen.py
@@ -42,7 +42,6 @@ This module uses `pyahocorasick`:
 from operator import attrgetter
 from itertools import product
 from itertools import combinations
-from itertools import pairwise
 from collections import defaultdict
 from collections import namedtuple
 from collections.abc import Callable
@@ -70,15 +69,17 @@ amplicon_tuple = namedtuple(
 primer_tuple = namedtuple(typename="primer_tuple", field_names="seq, fp, rp, size")
 
 
-def closest_diff(nums: list[int]) -> int:
+def closest_pair_and_diff(nums: list[int]) -> int:
     """
     Smallest difference between two consecutive integers in a sorted list.
 
-    Given a list of integers eg. 1, 5, 7, 11, 19, return the smallest
-    absolute difference, in this case 7-5 = 2.
+    Given a list of integers eg. 1, 5, 7, 11, 19, return the consequtive pair
+    with the smallest difference and the difference. If more than one pair
+    gives the same difference, return the larger pair.
 
-    >>> closest_diff([1, 5, 7, 11, 19])
-    2
+    >>> nums = [1, 5, 7, 11, 19, 21]
+    >>> closest_pair_and_diff(nums)
+    ((19, 21), 2)
 
 
     Parameters
@@ -97,19 +98,11 @@ def closest_diff(nums: list[int]) -> int:
         Diff, always >= 0.
 
     """
-    if len(nums) < 2:
-        raise ValueError("Need at least two numbers")
-
-    nums = sorted(nums)
-    min_diff = float("inf")
-
-    for a, b in zip(nums, nums[1:]):
-        diff = abs(a - b)
-        if diff < min_diff:
-            min_diff = diff
-            x, y = a, b
-
-    return abs(x - y)
+    assert len(nums) > 1, "Need at least two numbers"
+    nums.sort()
+    diff_dict = {b - a: (a, b) for a, b in zip(nums, nums[1:])}
+    diff = min(diff_dict.keys())
+    return diff_dict[diff], diff
 
 
 def expand_iupac_to_dna(seq: str) -> list[str]:
@@ -696,42 +689,38 @@ def diff_primer_pairs(
 
     automaton = automaton or make_automaton(primer_list, limit=limit)
     limit = automaton.get_stats()["longest_word"]
-    primer_pair_dict = defaultdict(dict)
+    primer_pair_dict = defaultdict(list)
+
+    sequences = list(dict.fromkeys(sequences))
     number_of_sequences = len(sequences)
 
+    # primer pairs from all sequences are collected in a defaultdict.
+    #
     for seq in sequences:
-
-        for fp, rp, *_, size in primer_pairs(
+        for pp in primer_pairs(
             seq, primer_list, short=short, long=long, limit=limit, automaton=automaton
         ):
-
-            primer_pair_dict[frozenset((fp, rp))][size] = fp, rp, seq
-
-    primer_pair_dict = {
-        k: v for k, v in primer_pair_dict.items() if len(v) == number_of_sequences
-    }
-
-    primer_pair_dict = {
-        k: v
-        for k, v in primer_pair_dict.items()
-        if all(callback(a, b) for a, b in pairwise(v.keys()))
-    }
+            primer_pair_dict[frozenset((pp.fp, pp.rp))].append((pp, seq))
 
     result = []
-
-    for primer_pair, seqd in primer_pair_dict.items():
-        result.append(
-            (
-                closest_diff(seqd.keys()),
-                tuple(
-                    primer_tuple(s, fp, rp, size) for size, (fp, rp, s) in seqd.items()
-                ),
-            )
-        )
-
+    for k, v in primer_pair_dict.items():
+        # verify one pcr product per sequence
+        if len(v) == number_of_sequences:
+            # we need the closest pair to see if the bands are likely to resolve
+            closest_pair, diff = closest_pair_and_diff([pp.size for pp, _ in v])
+            if callback(*closest_pair):
+                # we add the diff here so we can sort the results by this value
+                # we normally want a large difference in size
+                result.append(
+                    (
+                        diff,
+                        tuple(
+                            primer_tuple(seq, pp.fp, pp.rp, pp.size) for pp, seq in v
+                        ),
+                    )
+                )
     result.sort(reverse=True)
-
-    return [b for a, b in result]
+    return [pts for diff, pts in result]
 
 
 def diff_primer_triplets(
@@ -767,7 +756,8 @@ def diff_primer_triplets(
          1>      <3
         -------NNNNN--------  sequenceN-1
 
-
+         2>      <3
+        -AA----NNNNN--------  sequenceN
 
     The callback function is used to give a score for the PCR products. This score can
     be used to decide if a collection of PCR products are likely to migrate to distinct
@@ -815,57 +805,61 @@ def diff_primer_triplets(
     automaton = automaton or make_automaton(primer_list, limit=limit)
     limit = automaton.get_stats()["longest_word"]
     # number_of_sequences = len(sequences)
+    sequences = list(dict.fromkeys(sequences))
     sequence_set = set(sequences)
     # primer pairs for each sequence are collected together with the
     # primer pairs in a defaultdict(list) where the key of a frozenset
     # of the primer pair numbers.
 
-    pairs = defaultdict(list)
+    pairs = defaultdict(dict)
 
     for seq in sequences:
-        pps = primer_pairs(
+        primerpairs_for_one_sequence = primer_pairs(
             seq, primer_list, short=short, long=long, limit=limit, automaton=automaton
         )
-        for pp in pps:
-            pairs[frozenset((pp.fp, pp.rp))].append((seq, pp))
+        for pp in primerpairs_for_one_sequence:
+            pairs[seq][pp.fp, pp.rp] = pp
+
+    trios = defaultdict(list)
 
     # All collected primer pairs are compared and collected if they share a
     # primer (a trio). The trios are collected in another defaultdict(list)
 
-    trios = defaultdict(list)
+    for one, two in combinations(pairs, 2):
+        for p1, pt1 in pairs[one].items():
+            for p2, pt2 in pairs[two].items():
+                if len(trio := frozenset(p1 + p2)) == 3:
+                    trios[trio].extend(((one, pt1), (two, pt2)))
 
-    for keys in combinations(pairs, 2):
-        union = frozenset().union(*keys)
-        if len(union) == 3:
-            for key in keys:
-                trios[union].extend(pairs[key])
-
-    intermediate_result = []
+    # We loop through all values in trios and filter:
+    # at least one primer pair for each sequence
+    trios = {
+        trio: values
+        for trio, values in trios.items()
+        # filter dict for trios that have a PCR product from all sequences
+        if set(s for s, _ in values) == sequence_set
+    }
 
     # Each key, value pair in trios look like this:
     #
-    #   frozenset({1,2,3}) = [(seq1, pair1), (seq2, pair2), ... (seqN, pairN)]
+    #   trios[(1,2,3)] = [(seq1, pair1), (seq2, pair2), ... (seqN, pairN)]
     #
-    # seq is a Dseqrecord
-    # pair is an amplicon_tuple(fp, rp, fposition, rposition, size)
+    # (1,2,3) is a triplet of primer numbers (integers)
+    # seq1 .. seqN are sequences fed to the function
+    # pair1 .. pairN is an amplicon_tuple(fp, rp, fposition, rposition, size)
     #
-    # We loop through all values in trios and filter:
-    # - at least one primer pair for each sequence
     # - visible differences between band sizes = callback true for all pairs if product sizes
     #
     # collect in intermediate_result.
 
-    for seq_primer_tuples in trios.values():
-        templates = []
-        sizes = []
-        for seq, pair in seq_primer_tuples:
-            templates.append(seq)
-            sizes.append(pair.size)
+    intermediate_result = []
 
-        if sequence_set == set(templates) and all(
-            callback(x, y) for x, y in combinations(sizes, 2)
-        ):
-            intermediate_result.append((closest_diff(sizes), seq_primer_tuples))
+    for seq_primer_tuples in trios.values():
+        closest_pair, diff = closest_pair_and_diff(
+            [pair.size for seq, pair in seq_primer_tuples]
+        )
+        if callback(*closest_pair):
+            intermediate_result.append((diff, seq_primer_tuples))
 
     # The closest difference between any two product sizes is also collected
     # so we can sort results for primer combos that produce the largest

--- a/src/pydna/primer_screen.py
+++ b/src/pydna/primer_screen.py
@@ -69,6 +69,63 @@ amplicon_tuple = namedtuple(
 primer_tuple = namedtuple(typename="primer_tuple", field_names="seq, fp, rp, size")
 
 
+def contained(a: int, b: int, x: int, y: int, L: int, circular=True) -> bool:
+    """
+    Test whether interval (a, b) is contained in interval (x, y)
+    in a sequence of length L. The sequence may be linear or circular.
+
+    Coordinates must satisfy 0 <= coordinate <= L.
+
+    If circular=False, intervals are treated as ordinary linear intervals.
+
+    If circular=True, intervals are treated as directed circular intervals:
+    - (4, 8) means 4 -> 8
+    - (9, 1) means 9 -> L -> 0 -> 1
+    """
+
+    assert L >= 1, "L must be a positive integer"
+
+    def valid_coordinate(n: int) -> bool:
+        return 0 <= n <= L
+
+    if not all(valid_coordinate(n) for n in (a, b, x, y)):
+        return False
+
+    if not circular:
+        assert a <= b, "In a linear interval, a <= b"
+        assert x <= y, "In a linear interval, x <= y"
+        return x <= a and b <= y
+
+    def unwrap(start: int, end: int) -> tuple[int, int]:
+        """
+        Convert a circular interval into a linear interval.
+
+        Examples with L=10:
+        (4, 8) -> (4, 8)
+        (9, 1) -> (9, 11)
+        (9, 10) -> (9, 10)
+        """
+        start = start % L
+        end = end % L
+
+        if end < start:
+            end += L
+
+        return start, end
+
+    aa, bb = unwrap(a, b)
+    xx, yy = unwrap(x, y)
+
+    for shift in (-L, 0, L):
+        aaa = aa + shift
+        bbb = bb + shift
+
+        if xx <= aaa and bbb <= yy:
+            return True
+
+    return False
+
+
 def closest_pair_and_diff(nums: list[int]) -> int:
     """
     Smallest difference between two consecutive integers in a sorted list.
@@ -584,7 +641,6 @@ def flanking_primer_pairs(
 
     assert begin is not None, "begin has to be set."
     assert end is not None, "end has to be set."
-    assert begin < end, "begin has to be smaller than end."
 
     amplicons = primer_pairs(
         seq,
@@ -597,16 +653,15 @@ def flanking_primer_pairs(
     products = []
 
     for amplicon in amplicons:
-        if amplicon.fposition <= begin and end <= amplicon.rposition:
+        if contained(
+            begin,
+            end,
+            amplicon.fposition,
+            amplicon.rposition,
+            len(seq),
+            circular=seq.circular,
+        ):
             products.append(amplicon)
-    if seq.circular:
-        for amplicon in amplicons:
-            if (
-                amplicon.fposition > amplicon.rposition
-                and begin >= amplicon.fposition % len(seq)
-                and end <= amplicon.rposition % len(seq)
-            ):
-                products.append(amplicon)
 
     return sorted(products, key=attrgetter("size"))  # results sorted by size
 

--- a/src/pydna/primer_screen.py
+++ b/src/pydna/primer_screen.py
@@ -44,8 +44,6 @@ from itertools import product
 from itertools import combinations
 from itertools import pairwise
 from collections import defaultdict
-
-# from collections import Counter
 from collections import namedtuple
 from collections.abc import Callable
 from collections.abc import Sequence
@@ -335,7 +333,7 @@ def forward_primers(
     # A defaultdict of lists is used to collect primer locations since
     # different primers can anneal in the same place.
     fps = defaultdict(list)
-
+    # if seq is circular, we have to look across the origin of the sequence
     seq = seq[:] + seq[: limit - 1] if seq.circular else seq
 
     for end_index, ids in automaton.iter(str(seq.seq).upper()):
@@ -418,6 +416,7 @@ def reverse_primers(
     # A defaultdict of lists is used to collect primer locations since
     # different primers can anneal in the same place.
     rps = defaultdict(list)
+    # if seq is circular, we have to look across the origin of the sequence
     seq = seq[:] + seq[: limit - 1] if seq.circular else seq
     ln = len(seq)
 

--- a/tests/pIL68.gb
+++ b/tests/pIL68.gb
@@ -1,11 +1,12 @@
-LOCUS       pIL68                   4852 bp    DNA     circular     07-NOV-2025
+LOCUS       pIL68                   4852 bp    DNA     circular     29-APR-2026
 DEFINITION  .
 ACCESSION   .
 VERSION     .
 KEYWORDS    .
-SOURCE      
+SOURCE
   ORGANISM  . .
-COMMENT     
+COMMENT
+COMMENT
 COMMENT     ApEinfo:methylated:1
 FEATURES             Location/Qualifiers
      misc_feature    complement(join(4533..4568,4570..4582))
@@ -338,8 +339,8 @@ ORIGIN
         1 tcgcgcgttt cggtgatgac ggtgaaaacc tctgacacat gcagctcccg gagacggtca
        61 cagcttgtct gtaagcggat gccgggagca gacaagcccg tcagggcgcg tcagcgggtg
       121 ttggcgggtg tcggggctgg cttaactatg cggcatcaga gcagattgta ctgagagtgc
-      181 accataccac agcttttcaa ttcaattcat catttttttt ttattctttt ttttgatttc
-      241 ggtttctttg aaattttttt gattcggtaa tctccgaaca gaaggaagaa cgaaggaagg
+      181 accataccac agcttttcaa ttcaattcat catttttttt ttattctttt ttttgatttC
+      241 GGTTTCTTTG AAATTTTTTT GATTCGgtaa tctccgaaca gaaggaagaa cgaaggaagg
       301 agcacagact tagattggta tatatacgca tatgtagtgt tgaagaaaca tgaaattgcc
       361 cagtattctt aacccaactg cacagaacaa aaacctgcag gaaacgaaga taaatcatgt
       421 cgaaagctac atataaggaa cgtgctgcta ctcatcctag tcctgttgct gccaagctat
@@ -363,7 +364,7 @@ ORIGIN
      1501 agagtccact attaaagaac gtggactcca acgtcaaagg gcgaaaaacc gtctatcagg
      1561 gcgatggccc actacgtgaa ccatcaccct aatcaagttt tttggggtcg aggtgccgta
      1621 aagcactaaa tcggaaccct aaagggagcc cccgatttag agcttgacgg ggaaagccgg
-     1681 cgaacgtggc gagaaaggaa gggaagaaag cgaaaggagc gggcgctagg gcgctggcaa
+     1681 cgaacgtggC GAGAAAGGAA GGGAAGAAAG CGAaaggagc gggcgctagg gcgctggcaa
      1741 gtgtagcggt cacgctgcgc gtaaccacca cacccgccgc gcttaatgcg ccgctacagg
      1801 gcgcgtcgcg ccattcgcca ttcaggctgc gcaactgttg ggaagggcga tcggtgcggg
      1861 cctcttcgct attacgccag ctggcgaaag ggggatgtgc tgcaaggcga ttaagttggg

--- a/tests/pIL75.gb
+++ b/tests/pIL75.gb
@@ -1,220 +1,371 @@
-LOCUS       pIL75                   5213 bp    DNA     circular SYN 07-JAN-2015
+LOCUS       pIL75                   5213 bp    DNA     circular     29-APR-2026
 DEFINITION  .
 ACCESSION   .
 VERSION     .
 KEYWORDS    .
-SOURCE      
-  ORGANISM  .
-            .
-COMMENT     Annotated with pLannotate v1.2.2.            
-            ApEinfo:methylated:1
+SOURCE
+  ORGANISM  . .
+COMMENT
+COMMENT     ApEinfo:methylated:1
 FEATURES             Location/Qualifiers
      misc_feature    4692..5143
+                     /locus_tag="panARS"
                      /label="panARS"
+                     /ApEinfo_label="panARS"
                      /ApEinfo_fwdcolor="#ff8000"
                      /ApEinfo_revcolor="#ff8000"
                      /ApEinfo_graphicformat="arrow_data {{0 1 2 0 0 -1} {} 0}
                      width 5 offset 0"
      gene            251..1607
                      /note="pLannotate"
-                     /label="kanMX"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="gene"
+                     /locus_tag="kanMX"
+                     /label="kanMX"
+                     /ApEinfo_label="kanMX"
+                     /ApEinfo_fwdcolor="#ff797d"
+                     /ApEinfo_revcolor="#ff102f"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      CDS             595..1404
                      /note="pLannotate"
-                     /label="KanR"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="CDS"
+                     /locus_tag="KanR"
+                     /label="KanR"
+                     /ApEinfo_label="KanR"
+                     /ApEinfo_fwdcolor="#e9d024"
+                     /ApEinfo_revcolor="#e9d024"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      rep_origin      complement(2936..3524)
                      /note="pLannotate"
-                     /label="ori"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="rep_origin"
+                     /locus_tag="ori"
+                     /label="ori"
+                     /ApEinfo_label="ori"
+                     /ApEinfo_fwdcolor="#999999"
+                     /ApEinfo_revcolor="#999999"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      rep_origin      complement(1722..2177)
                      /note="pLannotate"
-                     /label="f1 ori"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="rep_origin"
+                     /locus_tag="f1 ori"
+                     /label="f1 ori"
+                     /ApEinfo_label="f1 ori"
+                     /ApEinfo_fwdcolor="#999999"
+                     /ApEinfo_revcolor="#999999"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      promoter        251..594
                      /note="pLannotate"
-                     /label="TEF promoter"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="promoter"
+                     /locus_tag="TEF promoter"
+                     /label="TEF promoter"
+                     /ApEinfo_label="TEF promoter"
+                     /ApEinfo_fwdcolor="#346ee0"
+                     /ApEinfo_revcolor="#346ee0"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      terminator      1410..1607
                      /note="pLannotate"
-                     /label="TEF terminator"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="terminator"
+                     /locus_tag="TEF terminator"
+                     /label="TEF terminator"
+                     /ApEinfo_label="TEF terminator"
+                     /ApEinfo_fwdcolor="#9d1b1c"
+                     /ApEinfo_revcolor="#9d1b1c"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      misc_feature    complement(2375..2482)
                      /note="pLannotate"
-                     /label="MCS"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="misc_feature"
+                     /locus_tag="MCS"
+                     /label="MCS"
+                     /ApEinfo_label="MCS"
+                     /ApEinfo_fwdcolor="#7eff74"
+                     /ApEinfo_revcolor="#7eff74"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      promoter        complement(4556..4660)
                      /note="pLannotate"
-                     /label="AmpR promoter"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="promoter"
+                     /locus_tag="AmpR promoter"
+                     /label="AmpR promoter"
+                     /ApEinfo_label="AmpR promoter"
+                     /ApEinfo_fwdcolor="#346ee0"
+                     /ApEinfo_revcolor="#346ee0"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      CDS             complement(3695..4555)
                      /note="pLannotate"
-                     /label="AmpR"
                      /database="snapgene"
                      /identity="99.8"
                      /match_length="100.0"
                      /fragment="False"
                      /other="CDS"
+                     /locus_tag="AmpR"
+                     /label="AmpR"
+                     /ApEinfo_label="AmpR"
+                     /ApEinfo_fwdcolor="#e9d024"
+                     /ApEinfo_revcolor="#e9d024"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      promoter        complement(2582..2612)
                      /note="pLannotate"
-                     /label="lac promoter"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="promoter"
+                     /locus_tag="lac promoter"
+                     /label="lac promoter"
+                     /ApEinfo_label="lac promoter"
+                     /ApEinfo_fwdcolor="#346ee0"
+                     /ApEinfo_revcolor="#346ee0"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      protein_bind    complement(2627..2648)
                      /note="pLannotate"
-                     /label="CAP binding site"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="protein_bind"
+                     /locus_tag="CAP binding site"
+                     /label="CAP binding site"
+                     /ApEinfo_label="CAP binding site"
+                     /ApEinfo_fwdcolor="#00DF87"
+                     /ApEinfo_revcolor="#00DF87"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      promoter        2348..2366
                      /note="pLannotate"
-                     /label="T7 promoter"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="promoter"
+                     /locus_tag="T7 promoter"
+                     /label="T7 promoter"
+                     /ApEinfo_label="T7 promoter"
+                     /ApEinfo_fwdcolor="#346ee0"
+                     /ApEinfo_revcolor="#346ee0"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      promoter        complement(2495..2513)
                      /note="pLannotate"
-                     /label="T3 promoter"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="promoter"
+                     /locus_tag="T3 promoter"
+                     /label="T3 promoter"
+                     /ApEinfo_label="T3 promoter"
+                     /ApEinfo_fwdcolor="#346ee0"
+                     /ApEinfo_revcolor="#346ee0"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      protein_bind    complement(2558..2574)
                      /note="pLannotate"
-                     /label="lac operator"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="100.0"
                      /fragment="False"
                      /other="protein_bind"
+                     /locus_tag="lac operator"
+                     /label="lac operator"
+                     /ApEinfo_label="lac operator"
+                     /ApEinfo_fwdcolor="#00D95A"
+                     /ApEinfo_revcolor="#00D95A"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      CDS             complement(2185..2340)
                      /note="pLannotate"
-                     /label="lacZα (fragment)"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="89.7"
                      /fragment="True"
                      /other="CDS"
+                     /locus_tag="lacZα (fragment)"
+                     /label="lacZα (fragment)"
+                     /ApEinfo_label="lacZα (fragment)"
+                     /ApEinfo_fwdcolor="#e9d024"
+                     /ApEinfo_revcolor="#e9d024"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      ncRNA           3379..3483
                      /note="pLannotate"
-                     /label="RNAI"
                      /database="Rfam"
                      /identity="100.0"
                      /match_length="102.9"
                      /fragment="False"
                      /other="ncRNA"
+                     /locus_tag="RNAI"
+                     /label="RNAI"
+                     /ApEinfo_label="RNAI"
+                     /ApEinfo_fwdcolor="#008065"
+                     /ApEinfo_revcolor="#008065"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      misc_feature    1670..1721
                      /note="pLannotate"
-                     /label="bom (fragment)"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="36.9"
                      /fragment="True"
                      /other="misc_feature"
+                     /locus_tag="bom (fragment)"
+                     /label="bom (fragment)"
+                     /ApEinfo_label="bom (fragment)"
+                     /ApEinfo_fwdcolor="#7eff74"
+                     /ApEinfo_revcolor="#7eff74"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      misc_feature    137..186
                      /note="pLannotate"
-                     /label="bom (fragment)"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="35.5"
                      /fragment="True"
                      /other="misc_feature"
+                     /locus_tag="bom (fragment)(1)"
+                     /label="bom (fragment)(1)"
+                     /ApEinfo_label="bom (fragment)"
+                     /ApEinfo_fwdcolor="#7eff74"
+                     /ApEinfo_revcolor="#7eff74"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      promoter        complement(2556..2574)
                      /note="pLannotate"
-                     /label="T5 promoter (fragment)"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="42.2"
                      /fragment="True"
                      /other="promoter"
+                     /locus_tag="T5 promoter (fragment)"
+                     /label="T5 promoter (fragment)"
+                     /ApEinfo_label="T5 promoter (fragment)"
+                     /ApEinfo_fwdcolor="#346ee0"
+                     /ApEinfo_revcolor="#346ee0"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      CDS             complement(2661..2753)
                      /note="pLannotate"
-                     /label="lacI (fragment)"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="8.6"
                      /fragment="True"
                      /other="CDS"
-     CDS             join(5213,1..35)
+                     /locus_tag="lacI (fragment)"
+                     /label="lacI (fragment)"
+                     /ApEinfo_label="lacI (fragment)"
+                     /ApEinfo_fwdcolor="#e9d024"
+                     /ApEinfo_revcolor="#e9d024"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
+     CDS             join(5213..5213,1..35)
                      /note="pLannotate"
-                     /label="rop (fragment)"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="18.8"
                      /fragment="True"
                      /other="CDS"
+                     /locus_tag="rop (fragment)"
+                     /label="rop (fragment)"
+                     /ApEinfo_label="rop (fragment)"
+                     /ApEinfo_fwdcolor="#e9d024"
+                     /ApEinfo_revcolor="#e9d024"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      intron          2348..2367
                      /note="pLannotate"
-                     /label="CMV intron (fragment)"
                      /database="snapgene"
                      /identity="100.0"
                      /match_length="18.2"
                      /fragment="True"
                      /other="intron"
+                     /locus_tag="CMV intron (fragment)"
+                     /label="CMV intron (fragment)"
+                     /ApEinfo_label="CMV intron (fragment)"
+                     /ApEinfo_fwdcolor="#eb606c"
+                     /ApEinfo_revcolor="#eb606c"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      CDS             complement(2567..2662)
                      /note="pLannotate"
-                     /label="penA (fragment)"
                      /database="swissprot"
                      /identity="68.8"
                      /match_length="10.2"
                      /fragment="True"
                      /other="CDS"
+                     /locus_tag="penA (fragment)"
+                     /label="penA (fragment)"
+                     /ApEinfo_label="penA (fragment)"
+                     /ApEinfo_fwdcolor="#e9d024"
+                     /ApEinfo_revcolor="#e9d024"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      CDS             complement(2373..2429)
                      /note="pLannotate"
-                     /label="H1L1_OSTED (fragment)"
                      /database="swissprot"
                      /identity="100.0"
                      /match_length="9.4"
                      /fragment="True"
                      /other="CDS"
+                     /locus_tag="H1L1_OSTED (fragment)"
+                     /label="H1L1_OSTED (fragment)"
+                     /ApEinfo_label="H1L1_OSTED (fragment)"
+                     /ApEinfo_fwdcolor="#e9d024"
+                     /ApEinfo_revcolor="#e9d024"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
      CDS             218..307
                      /note="pLannotate"
-                     /label="MRL1 (fragment)"
                      /database="swissprot"
                      /identity="100.0"
                      /match_length="11.0"
                      /fragment="True"
                      /other="CDS"
+                     /locus_tag="MRL1 (fragment)"
+                     /label="MRL1 (fragment)"
+                     /ApEinfo_label="MRL1 (fragment)"
+                     /ApEinfo_fwdcolor="#e9d024"
+                     /ApEinfo_revcolor="#e9d024"
+                     /ApEinfo_graphicformat="arrow_data {{0 0.5 0 1 2 0 0 -1 0
+                     -0.5} {0 .5 .1 .5 .1 -.5 0 -.5} 0} width 5 offset 0"
 ORIGIN
         1 tcgcgcgttt cggtgatgac ggtgaaaacc tctgacacat gcagctcccg gagacggtca
        61 cagcttgtct gtaagcggat gccgggagca gacaagcccg tcagggcgcg tcagcgggtg
@@ -241,7 +392,7 @@ ORIGIN
      1321 aaacggcttt ttcaaaaata tggtattgat aatcctgata tgaataaatt gcagtttcat
      1381 ttgatgctcg atgagttttt ctaatcagta ctgacaataa aaagattctt gttttcaaga
      1441 acttgtcatt tgtatagttt ttttatattg tagttgttct attttaatca aatgttagcg
-     1501 tgatttatat tttttttcgc ctcgacatca tctgcccaga tgcgaagtta agtgcgcaga
+     1501 tgatttatat tttttttcgc ctcgacatca tctgccCAGA TGCGAAGTTA AGTGCGcaga
      1561 aagtaatatc atgcgtcaat cgtatgtgaa tgctggtcgc tatactgctg tcgattcgat
      1621 actaacgccg ccatccagtg tcgaaaacga gctcgaattc atcgatgatt atgcggtgtg
      1681 aaataccgca cagatgcgta aggagaaaat accgcatcag gaaattgtaa acgttaatat
@@ -250,7 +401,7 @@ ORIGIN
      1861 agtttggaac aagagtccac tattaaagaa cgtggactcc aacgtcaaag ggcgaaaaac
      1921 cgtctatcag ggcgatggcc cactacgtga accatcaccc taatcaagtt ttttggggtc
      1981 gaggtgccgt aaagcactaa atcggaaccc taaagggagc ccccgattta gagcttgacg
-     2041 gggaaagccg gcgaacgtgg cgagaaagga agggaagaaa gcgaaaggag cgggcgctag
+     2041 gggaaagccg gcgaacgtgg CGAGAAAGGA AGGGAAGAAA GCGAaaggag cgggcgctag
      2101 ggcgctggca agtgtagcgg tcacgctgcg cgtaaccacc acacccgccg cgcttaatgc
      2161 gccgctacag ggcgcgtcgc gccattcgcc attcaggctg cgcaactgtt gggaagggcg
      2221 atcggtgcgg gcctcttcgc tattacgcca gctggcgaaa gggggatgtg ctgcaaggcg

--- a/tests/test_module_primer_screen.py
+++ b/tests/test_module_primer_screen.py
@@ -8,9 +8,11 @@ import pickle
 import pathlib
 import ahocorasick
 
+from pydna.primer import Primer
 from pydna.readers import read
 from pydna.amplify import pcr
 from pydna.parsers import parse_primers
+from pydna.dseqrecord import Dseqrecord
 
 from pydna.primer_screen import make_automaton
 from pydna.primer_screen import forward_primers
@@ -125,8 +127,8 @@ def test_flanking_primer_pairs():
     result = flanking_primer_pairs(kan, pl, target=(550, 1200), automaton=atm)
 
     answer = [
-        amplicon_tuple(fp=82, rp=1564, fposition=1168, rposition=1940, size=809),
-        amplicon_tuple(fp=82, rp=149, fposition=1168, rposition=2306, size=1181),
+        amplicon_tuple(fp=701, rp=1564, fposition=534, rposition=1940, size=1450),
+        amplicon_tuple(fp=701, rp=149, fposition=534, rposition=2306, size=1822),
     ]
     assert result == answer
 
@@ -182,3 +184,50 @@ def test_diff_primer_triplets_2():
 
     with pytest.raises(ValueError, match="No PCR product!"):
         pcr(pl[1215], pl[594], pIL75)
+
+    s = primers[0] + "aaa" + primers[1].rc()
+
+    s = "CAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGA"
+
+    assert primer_pairs(Dseqrecord(s), pl, short=0) == [
+        amplicon_tuple(fp=51, rp=82, fposition=20, rposition=23, size=41)
+    ]
+
+    # >51_TefTermFwd A.gos 20-mer
+    # CAGATGCGAAGTTAAGTGCG
+
+    # >82_MSW_fwd this primer sits inside the loxP of pUG6
+    # TCCTTGACAGTCTTGACG
+
+    #      CAGATGCGAAGTTAAGTGCG
+    # AAGGACAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTC
+    #                             CGTCAAGACTGTCAAGGA
+
+    assert primer_pairs(Dseqrecord(s[-5:] + s[:-5], circular=True), pl, short=0) == [
+        amplicon_tuple(fp=51, rp=82, fposition=25, rposition=28, size=41)
+    ]
+
+    assert primer_pairs(Dseqrecord(s[5:] + s[:5], circular=True), pl, short=0) == [
+        amplicon_tuple(fp=51, rp=82, fposition=56, rposition=18, size=41)
+    ]
+
+    f = Primer("CTCACTTGAAGTAATG", name="1")
+    r = Primer("AGAGGTTTGGTAGGTG", name="2")
+
+    t = Dseqrecord("CTCACTTGAAGTAATGTATCGTGCACCTACCAAACCTCT")
+
+    automaton = make_automaton([f, r])
+
+    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == [
+        amplicon_tuple(fp=0, rp=1, fposition=16, rposition=23, size=39)
+    ]
+
+    t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG")
+
+    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == []
+
+    t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG", circular=True)
+
+    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == [
+        amplicon_tuple(fp=0, rp=1, fposition=39, rposition=7, size=39)
+    ]

--- a/tests/test_module_primer_screen.py
+++ b/tests/test_module_primer_screen.py
@@ -376,6 +376,15 @@ def test_diff_primer_pairs():
         ),
     ]
 
+    f = Primer("CTCACTTGAAGTAATG", name="1")
+    r = Primer("AGAGGTTTGGTAGGTG", name="2")
+
+    t1 = Dseqrecord("CTCACTTGAAGTAATGtaTCGTGCACCTACCAAACCTCT")
+    t2 = Dseqrecord("CTCACTTGAAGTAATGccTCGTGCACCTACCAAACCTCT")
+    automaton2 = make_automaton([f, r])
+
+    assert diff_primer_pairs((t1, t2), [f, r], automaton=automaton2) == []
+
 
 def test_diff_primer_triplets():
 
@@ -420,3 +429,13 @@ def test_diff_primer_triplets():
 
     with pytest.raises(ValueError, match="No PCR product!"):
         pcr(pl[1215], pl[594], pIL75)
+
+    f = Primer("CTCACTTGAAGTAATG", name="1")
+    r = Primer("AGAGGTTTGGTAGGTG", name="2")
+    r2 = Primer("AAGCATAACACACGTA", name="2")
+
+    t1 = Dseqrecord("CTCACTTGAAGTAATGtaTCGTGCACCTACCAAACCTCT")
+    t2 = Dseqrecord("CTCACTTGAAGTAATGccAGCTATACGTGTGTTATGCTT")
+    automaton2 = make_automaton([f, r, r2])
+
+    assert diff_primer_pairs((t1, t2), [f, r, r2], automaton=automaton2) == []

--- a/tests/test_module_primer_screen.py
+++ b/tests/test_module_primer_screen.py
@@ -194,33 +194,63 @@ def test_diff_primer_triplets_2():
 
     s = primers[0] + "aaa" + primers[1].rc()
 
+    # >51_TefTermFwd A.gos 20-mer
+    # CAGATGCGAAGTTAAGTGCG
+    # >82_MSW_fwd this primer sits inside the loxP of pUG6
+    # TCCTTGACAGTCTTGACG
+
+    # CAGATGCGAAGTTAAGTGCG
+    # ||||||||||||||||||||
+    # CAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGA
+    # GTCTACGCTTCAATTCACGCtttGCAGTTCTGACAGTTCCT
+    #                        ||||||||||||||||||
+    #                        GCAGTTCTGACAGTTCCT
+
     s = "CAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGA"
 
     assert primer_pairs(Dseqrecord(s), pl, short=0) == [
         amplicon_tuple(fp=51, rp=82, fposition=20, rposition=23, size=41)
     ]
 
-    # >51_TefTermFwd A.gos 20-mer
-    # CAGATGCGAAGTTAAGTGCG
+    assert primer_pairs(Dseqrecord(s, circular=True), pl, short=0) == [
+        amplicon_tuple(fp=51, rp=82, fposition=20, rposition=23, size=41)
+    ]
 
-    # >82_MSW_fwd this primer sits inside the loxP of pUG6
-    # TCCTTGACAGTCTTGACG
-
-    #      CAGATGCGAAGTTAAGTGCG
-    # AAGGACAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTC
-    #                             CGTCAAGACTGTCAAGGA
+    #      CAGATGCGAAGTTAAGTGCG>
+    #      ||||||||||||||||||||
+    # AAGGACAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTC                       Circular template
+    # TTCCTGTCTACGCTTCAATTCACGCtttGCAGTTCTGACAG
+    #                                          AAGGACAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTC
+    #                                          TTCCTGTCTACGCTTCAATTCACGCtttGCAGTTCTGACAG
+    #                             ||||||||||||||||||
+    #                            <GCAGTTCTGACAGTTCCT
 
     assert primer_pairs(Dseqrecord(s[-5:] + s[:-5], circular=True), pl, short=0) == [
         amplicon_tuple(fp=51, rp=82, fposition=25, rposition=28, size=41)
     ]
 
+    #                                     CAGATGCGAAGTTAAGTGCG>
+    #                                     ||||||||||||||||||||
+    # GCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGACAGAT                        Circular template
+    # CGCTTCAATTCACGCtttGCAGTTCTGACAGTTCCTGTCTA
+    #                                          GCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGACAGAT
+    #                                          CGCTTCAATTCACGCtttGCAGTTCTGACAGTTCCTGTCTA
+    #                   ||||||||||||||||||
+    #                  <GCAGTTCTGACAGTTCCT
+
     assert primer_pairs(Dseqrecord(s[5:] + s[:5], circular=True), pl, short=0) == [
         amplicon_tuple(fp=51, rp=82, fposition=56, rposition=18, size=41)
     ]
 
+    # CTCACTTGAAGTAATG
+    # ||||||||||||||||
+    # CTCACTTGAAGTAATGTATCGTGCACCTACCAAACCTCT
+    # GAGTGAACTTCATTACATAGCACGTGGATGGTTTGGAGA
+    #                        ||||||||||||||||
+    #                        GTGGATGGTTTGGAGA
+
     f = Primer("CTCACTTGAAGTAATG", name="1")
     r = Primer("AGAGGTTTGGTAGGTG", name="2")
-
     t = Dseqrecord("CTCACTTGAAGTAATGTATCGTGCACCTACCAAACCTCT")
 
     automaton = make_automaton([f, r])
@@ -229,12 +259,41 @@ def test_diff_primer_triplets_2():
         amplicon_tuple(fp=0, rp=1, fposition=16, rposition=23, size=39)
     ]
 
+    #                        CTCACTTGAAGTAATG>
+    #                        ||||||||||||||||
+    # TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG   Linear template
+    # ATAGCACGTGGATGGTTTGGAGAGAGTGAACTTCATTAC   No product
+    #        ||||||||||||||||
+    #        GTGGATGGTTTGGAGA
+
     t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG")
 
     assert primer_pairs(t, [f, r], automaton=automaton, short=0) == []
+
+    #                        CTCACTTGAAGTAATG>
+    #                        ||||||||||||||||
+    # TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG   Circular template
+    # ATAGCACGTGGATGGTTTGGAGAGAGTGAACTTCATTAC   On product across the ori
+    #        ||||||||||||||||
+    #       <GTGGATGGTTTGGAGA
 
     t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG", circular=True)
 
     assert primer_pairs(t, [f, r], automaton=automaton, short=0) == [
         amplicon_tuple(fp=0, rp=1, fposition=39, rposition=7, size=39)
+    ]
+
+    #                           CTCACTTGAAGTAATG>
+    #                           ||||||||||||||||           Circular template
+    # ATGTATCGTGCACCTACCAAACCTCTCTCACTTGAAGTA              On product across the ori
+    # TACATAGCACGTGGATGGTTTGGAGAGAGTGAACTTCAT
+    #                                        ATGTATCGTGCACCTACCAAACCTCTCTCACTTGAAGTA
+    #                                        TACATAGCACGTGGATGGTTTGGAGAGAGTGAACTTCAT
+    #           ||||||||||||||||
+    #          <GTGGATGGTTTGGAGA
+
+    t = Dseqrecord("ATGTATCGTGCACCTACCAAACCTCTCTCACTTGAAGTA", circular=True)
+
+    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == [
+        amplicon_tuple(fp=0, rp=1, fposition=42, rposition=10, size=39)
     ]

--- a/tests/test_module_primer_screen.py
+++ b/tests/test_module_primer_screen.py
@@ -77,7 +77,6 @@ kan = read(test_files / "fas2__KanMX4_locus.gb")
 pIL68 = read(test_files / "pIL68.gb")
 pIL75 = read(test_files / "pIL75.gb")
 
-
 atm = None
 
 
@@ -132,6 +131,8 @@ def test_primer_pairs():
 
     s = str(primers[0].seq + "aaa" + primers[1].rc().seq)
 
+    assert s == "CAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGA"
+
     # >51_TefTermFwd A.gos 20-mer
     # CAGATGCGAAGTTAAGTGCG
     # >82_MSW_fwd this primer sits inside the loxP of pUG6
@@ -143,8 +144,6 @@ def test_primer_pairs():
     # GTCTACGCTTCAATTCACGCtttGCAGTTCTGACAGTTCCT
     #                        ||||||||||||||||||
     #                        GCAGTTCTGACAGTTCCT
-
-    s = "CAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGA"
 
     assert primer_pairs(Dseqrecord(s), pl, short=0) == [
         amplicon_tuple(fp=51, rp=82, fposition=20, rposition=23, size=41)
@@ -193,10 +192,9 @@ def test_primer_pairs():
     f = Primer("CTCACTTGAAGTAATG", name="1")
     r = Primer("AGAGGTTTGGTAGGTG", name="2")
     t = Dseqrecord("CTCACTTGAAGTAATGTATCGTGCACCTACCAAACCTCT")
+    automaton2 = make_automaton([f, r])
 
-    automaton = make_automaton([f, r])
-
-    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == [
+    assert primer_pairs(t, [f, r], automaton=automaton2, short=0) == [
         amplicon_tuple(fp=0, rp=1, fposition=16, rposition=23, size=39)
     ]
 
@@ -209,7 +207,7 @@ def test_primer_pairs():
 
     t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG")
 
-    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == []
+    assert primer_pairs(t, [f, r], automaton=automaton2, short=0) == []
 
     #                        CTCACTTGAAGTAATG>
     #                        ||||||||||||||||
@@ -220,7 +218,7 @@ def test_primer_pairs():
 
     t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG", circular=True)
 
-    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == [
+    assert primer_pairs(t, [f, r], automaton=automaton2, short=0) == [
         amplicon_tuple(fp=0, rp=1, fposition=0, rposition=7, size=39)
     ]
 
@@ -235,7 +233,7 @@ def test_primer_pairs():
 
     t = Dseqrecord("ATGTATCGTGCACCTACCAAACCTCTCTCACTTGAAGTA", circular=True)
 
-    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == [
+    assert primer_pairs(t, [f, r], automaton=automaton2, short=0) == [
         amplicon_tuple(fp=0, rp=1, fposition=3, rposition=10, size=39)
     ]
 
@@ -266,20 +264,19 @@ def test_flanking_primer_pairs():
     f = Primer("CTCACTTGAAGTAATG", name="1")
     r = Primer("AGAGGTTTGGTAGGTG", name="2")
     t = Dseqrecord("CTCACTTGAAGTAATGTATCGTGCACCTACCAAACCTCT")
+    automaton2 = make_automaton([f, r])
 
-    automaton = make_automaton([f, r])
-
-    assert flanking_primer_pairs(t, [f, r], target=(16, 23), automaton=automaton) == [
+    assert flanking_primer_pairs(t, [f, r], target=(16, 23), automaton=automaton2) == [
         amplicon_tuple(fp=0, rp=1, fposition=16, rposition=23, size=39)
     ]
-    assert flanking_primer_pairs(t, [f, r], target=(17, 23), automaton=automaton) == [
+    assert flanking_primer_pairs(t, [f, r], target=(17, 23), automaton=automaton2) == [
         amplicon_tuple(fp=0, rp=1, fposition=16, rposition=23, size=39)
     ]
-    assert flanking_primer_pairs(t, [f, r], target=(16, 22), automaton=automaton) == [
+    assert flanking_primer_pairs(t, [f, r], target=(16, 22), automaton=automaton2) == [
         amplicon_tuple(fp=0, rp=1, fposition=16, rposition=23, size=39)
     ]
-    assert flanking_primer_pairs(t, [f, r], target=(15, 23), automaton=automaton) == []
-    assert flanking_primer_pairs(t, [f, r], target=(16, 24), automaton=automaton) == []
+    assert flanking_primer_pairs(t, [f, r], target=(15, 23), automaton=automaton2) == []
+    assert flanking_primer_pairs(t, [f, r], target=(16, 24), automaton=automaton2) == []
 
     #                        CTCACTTGAAGTAATG>
     #                        ||||||||||||||||
@@ -290,8 +287,8 @@ def test_flanking_primer_pairs():
 
     t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG")
 
-    assert flanking_primer_pairs(t, [f, r], target=(0, 7), automaton=automaton) == []
-    assert flanking_primer_pairs(t, [f, r], target=(1, 6), automaton=automaton) == []
+    assert flanking_primer_pairs(t, [f, r], target=(0, 7), automaton=automaton2) == []
+    assert flanking_primer_pairs(t, [f, r], target=(1, 6), automaton=automaton2) == []
 
     #                        CTCACTTGAAGTAATG>
     #                        ||||||||||||||||
@@ -302,9 +299,35 @@ def test_flanking_primer_pairs():
 
     t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG", circular=True)
 
-    assert flanking_primer_pairs(t, [f, r], target=(1, 6), automaton=automaton) == [
+    assert flanking_primer_pairs(t, [f, r], target=(1, 6), automaton=automaton2) == [
         amplicon_tuple(fp=0, rp=1, fposition=0, rposition=7, size=39)
     ]
+
+    #                       CTCACTTGAAGTAATG>
+    #                       ||||||||||||||||
+    # ATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATGT   Circular template
+    # TAGCACGTGGATGGTTTGGAGAGAGTGAACTTCATTACA  On product across the ori
+    #       ||||||||||||||||
+    #      <GTGGATGGTTTGGAGA
+
+    t = Dseqrecord("ATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATGT", circular=True)
+
+    answer = amplicon_tuple(fp=0, rp=1, fposition=38, rposition=6, size=39)
+
+    assert flanking_primer_pairs(t, [f, r], target=(1, 5), automaton=automaton2) == [
+        answer
+    ]
+    assert flanking_primer_pairs(t, [f, r], target=(0, 5), automaton=automaton2) == [
+        answer
+    ]
+    assert flanking_primer_pairs(t, [f, r], target=(39, 5), automaton=automaton2) == [
+        answer
+    ]
+    assert flanking_primer_pairs(t, [f, r], target=(38, 6), automaton=automaton2) == [
+        answer
+    ]
+    assert flanking_primer_pairs(t, [f, r], target=(37, 6), automaton=automaton2) == []
+    assert flanking_primer_pairs(t, [f, r], target=(38, 7), automaton=automaton2) == []
 
     #                           CTCACTTGAAGTAATG>
     #                           ||||||||||||||||           Circular template
@@ -317,8 +340,8 @@ def test_flanking_primer_pairs():
 
     t = Dseqrecord("ATGTATCGTGCACCTACCAAACCTCTCTCACTTGAAGTA", circular=True)
 
-    assert flanking_primer_pairs(t, [f, r], target=(0, 6), automaton=automaton) == []
-    assert flanking_primer_pairs(t, [f, r], target=(3, 9), automaton=automaton) == [
+    assert flanking_primer_pairs(t, [f, r], target=(0, 6), automaton=automaton2) == []
+    assert flanking_primer_pairs(t, [f, r], target=(3, 9), automaton=automaton2) == [
         amplicon_tuple(fp=0, rp=1, fposition=3, rposition=10, size=39)
     ]
 

--- a/tests/test_module_primer_screen.py
+++ b/tests/test_module_primer_screen.py
@@ -14,7 +14,7 @@ from pydna.amplify import pcr
 from pydna.parsers import parse_primers
 from pydna.dseqrecord import Dseqrecord
 
-from pydna.primer_screen import closest_diff
+from pydna.primer_screen import closest_pair_and_diff
 from pydna.primer_screen import make_automaton
 from pydna.primer_screen import forward_primers
 from pydna.primer_screen import reverse_primers
@@ -25,9 +25,7 @@ from pydna.primer_screen import diff_primer_triplets
 from pydna.primer_screen import primer_tuple
 from pydna.primer_screen import amplicon_tuple
 
-
 test_files = pathlib.Path(os.path.join(os.path.dirname(__file__)))
-
 
 primers = parse_primers(
     """
@@ -83,12 +81,13 @@ pIL75 = read(test_files / "pIL75.gb")
 atm = None
 
 
-def test_closest_diff():
+def test_closest_pair_and_diff():
 
-    assert closest_diff([1, 5, 7, 11, 19]) == 2
+    assert closest_pair_and_diff([1, 5, 7, 11, 19]) == ((5, 7), 2)
+    assert closest_pair_and_diff([1, 5, 7, 17, 19]) == ((17, 19), 2)
 
-    with pytest.raises(ValueError):
-        closest_diff([5])
+    with pytest.raises(AssertionError):
+        closest_pair_and_diff([5])
 
 
 def test_automaton():
@@ -338,31 +337,38 @@ def test_diff_primer_pairs():
 
 def test_diff_primer_triplets():
 
-    results = diff_primer_triplets((wt, kan), pl, automaton=atm)
-
-    assert results == [
+    triplets1 = diff_primer_triplets((wt, kan), pl, automaton=atm)
+    assert len(triplets1) == 1
+    results = [
         (
             primer_tuple(seq=wt, fp=701, rp=700, size=724),
             primer_tuple(seq=kan, fp=701, rp=1564, size=1450),
         ),
     ]
+    assert triplets1 == results
 
-    triplets = diff_primer_triplets([pIL68, pIL75], pl)
-
-    assert len(triplets) == 2
-
+    triplets2 = diff_primer_triplets([pIL68, pIL75], pl)
+    assert len(triplets2) == 4
     answer = [
         (
             primer_tuple(seq=pIL68, fp=1215, rp=594, size=1474),
             primer_tuple(seq=pIL75, fp=51, rp=594, size=548),
         ),
         (
+            primer_tuple(seq=pIL68, fp=595, rp=607, size=546),
+            primer_tuple(seq=pIL75, fp=255, rp=607, size=1467),
+        ),
+        (
             primer_tuple(seq=pIL68, fp=1215, rp=594, size=1474),
             primer_tuple(seq=pIL75, fp=255, rp=594, size=1005),
         ),
+        (
+            primer_tuple(seq=pIL68, fp=595, rp=607, size=546),
+            primer_tuple(seq=pIL75, fp=51, rp=607, size=1010),
+        ),
     ]
 
-    assert triplets == answer
+    assert triplets2 == answer
 
     assert len(pcr(pl[1215], pl[594], pIL68)) == 1474
     assert len(pcr(pl[51], pl[594], pIL75)) == 548

--- a/tests/test_module_primer_screen.py
+++ b/tests/test_module_primer_screen.py
@@ -13,7 +13,7 @@ from pydna.readers import read
 from pydna.amplify import pcr
 from pydna.parsers import parse_primers
 from pydna.dseqrecord import Dseqrecord
-
+from pydna.primer_screen import contained
 from pydna.primer_screen import closest_pair_and_diff
 from pydna.primer_screen import make_automaton
 from pydna.primer_screen import forward_primers
@@ -78,6 +78,25 @@ pIL68 = read(test_files / "pIL68.gb")
 pIL75 = read(test_files / "pIL75.gb")
 
 atm = None
+
+
+def test_contained():
+    assert contained(4, 7, 4, 8, 10, circular=True) is True
+    assert contained(5, 8, 4, 8, 10, circular=True) is True
+    assert contained(4, 8, 4, 8, 10, circular=True) is True
+
+    assert contained(4, 7, 4, 8, 10, circular=False) is True
+    assert contained(5, 8, 4, 8, 10, circular=False) is True
+    assert contained(4, 8, 4, 8, 10, circular=False) is True
+
+    assert contained(9, 10, 9, 1, 10, circular=True) is True
+    assert contained(9, 1, 9, 1, 10, circular=True) is True
+    assert contained(0, 1, 9, 1, 10, circular=True) is True
+
+    assert contained(1, 5, 6, 38, 39, circular=True) is False
+    assert contained(1, 5, 38, 6, 39, circular=True) is True
+
+    assert contained(1, 5, 6, 38, 1, circular=True) is False
 
 
 def test_closest_pair_and_diff():

--- a/tests/test_module_primer_screen.py
+++ b/tests/test_module_primer_screen.py
@@ -139,6 +139,62 @@ def test_flanking_primer_pairs():
         amplicon_tuple(fp=1215, rp=607, fposition=266, rposition=2157, size=1946),
     ]
 
+    # CTCACTTGAAGTAATG
+    # ||||||||||||||||
+    # CTCACTTGAAGTAATGTATCGTGCACCTACCAAACCTCT
+    # GAGTGAACTTCATTACATAGCACGTGGATGGTTTGGAGA
+    #                        ||||||||||||||||
+    #                        GTGGATGGTTTGGAGA
+
+    f = Primer("CTCACTTGAAGTAATG", name="1")
+    r = Primer("AGAGGTTTGGTAGGTG", name="2")
+    t = Dseqrecord("CTCACTTGAAGTAATGTATCGTGCACCTACCAAACCTCT")
+
+    automaton = make_automaton([f, r])
+
+    assert flanking_primer_pairs(t, [f, r], target=(16, 23), automaton=automaton) == [
+        amplicon_tuple(fp=0, rp=1, fposition=16, rposition=23, size=39)
+    ]
+
+    #                        CTCACTTGAAGTAATG>
+    #                        ||||||||||||||||
+    # TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG   Linear template
+    # ATAGCACGTGGATGGTTTGGAGAGAGTGAACTTCATTAC   No product
+    #        ||||||||||||||||
+    #       <GTGGATGGTTTGGAGA
+
+    t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG")
+
+    assert flanking_primer_pairs(t, [f, r], target=(1, 6), automaton=automaton) == []
+
+    #                        CTCACTTGAAGTAATG>
+    #                        ||||||||||||||||
+    # TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG   Circular template
+    # ATAGCACGTGGATGGTTTGGAGAGAGTGAACTTCATTAC   On product across the ori
+    #        ||||||||||||||||
+    #       <GTGGATGGTTTGGAGA
+
+    t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG", circular=True)
+
+    assert flanking_primer_pairs(t, [f, r], target=(1, 6), automaton=automaton) == [
+        amplicon_tuple(fp=0, rp=1, fposition=39, rposition=7, size=39)
+    ]
+
+    #                           CTCACTTGAAGTAATG>
+    #                           ||||||||||||||||           Circular template
+    # ATGTATCGTGCACCTACCAAACCTCTCTCACTTGAAGTA              On product across the ori
+    # TACATAGCACGTGGATGGTTTGGAGAGAGTGAACTTCAT
+    #                                        ATGTATCGTGCACCTACCAAACCTCTCTCACTTGAAGTA
+    #                                        TACATAGCACGTGGATGGTTTGGAGAGAGTGAACTTCAT
+    #           ||||||||||||||||
+    #          <GTGGATGGTTTGGAGA
+
+    t = Dseqrecord("ATGTATCGTGCACCTACCAAACCTCTCTCACTTGAAGTA", circular=True)
+
+    assert flanking_primer_pairs(t, [f, r], target=(1, 6), automaton=automaton) == [
+        amplicon_tuple(fp=0, rp=1, fposition=42, rposition=10, size=39)
+    ]
+
 
 def test_diff_primer_pairs():
 
@@ -194,47 +250,50 @@ def test_diff_primer_triplets_2():
 
     s = primers[0] + "aaa" + primers[1].rc()
 
+    # >51_TefTermFwd A.gos 20-mer
+    # CAGATGCGAAGTTAAGTGCG
+    # >82_MSW_fwd this primer sits inside the loxP of pUG6
+    # TCCTTGACAGTCTTGACG
+
+    # CAGATGCGAAGTTAAGTGCG
+    # ||||||||||||||||||||
+    # CAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGA
+    # GTCTACGCTTCAATTCACGCtttGCAGTTCTGACAGTTCCT
+    #                        ||||||||||||||||||
+    #                        GCAGTTCTGACAGTTCCT
+
     s = "CAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGA"
 
     assert primer_pairs(Dseqrecord(s), pl, short=0) == [
         amplicon_tuple(fp=51, rp=82, fposition=20, rposition=23, size=41)
     ]
 
-    # >51_TefTermFwd A.gos 20-mer
-    # CAGATGCGAAGTTAAGTGCG
+    assert primer_pairs(Dseqrecord(s, circular=True), pl, short=0) == [
+        amplicon_tuple(fp=51, rp=82, fposition=20, rposition=23, size=41)
+    ]
 
-    # >82_MSW_fwd this primer sits inside the loxP of pUG6
-    # TCCTTGACAGTCTTGACG
-
-    #      CAGATGCGAAGTTAAGTGCG
-    # AAGGACAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTC
-    #                             CGTCAAGACTGTCAAGGA
+    #      CAGATGCGAAGTTAAGTGCG>
+    #      ||||||||||||||||||||
+    # AAGGACAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTC                       Circular template
+    # TTCCTGTCTACGCTTCAATTCACGCtttGCAGTTCTGACAG
+    #                                          AAGGACAGATGCGAAGTTAAGTGCGaaaCGTCAAGACTGTC
+    #                                          TTCCTGTCTACGCTTCAATTCACGCtttGCAGTTCTGACAG
+    #                             ||||||||||||||||||
+    #                            <GCAGTTCTGACAGTTCCT
 
     assert primer_pairs(Dseqrecord(s[-5:] + s[:-5], circular=True), pl, short=0) == [
         amplicon_tuple(fp=51, rp=82, fposition=25, rposition=28, size=41)
     ]
 
+    #                                     CAGATGCGAAGTTAAGTGCG>
+    #                                     ||||||||||||||||||||
+    # GCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGACAGAT                        Circular template
+    # CGCTTCAATTCACGCtttGCAGTTCTGACAGTTCCTGTCTA
+    #                                          GCGAAGTTAAGTGCGaaaCGTCAAGACTGTCAAGGACAGAT
+    #                                          CGCTTCAATTCACGCtttGCAGTTCTGACAGTTCCTGTCTA
+    #                   ||||||||||||||||||
+    #                  <GCAGTTCTGACAGTTCCT
+
     assert primer_pairs(Dseqrecord(s[5:] + s[:5], circular=True), pl, short=0) == [
         amplicon_tuple(fp=51, rp=82, fposition=56, rposition=18, size=41)
-    ]
-
-    f = Primer("CTCACTTGAAGTAATG", name="1")
-    r = Primer("AGAGGTTTGGTAGGTG", name="2")
-
-    t = Dseqrecord("CTCACTTGAAGTAATGTATCGTGCACCTACCAAACCTCT")
-
-    automaton = make_automaton([f, r])
-
-    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == [
-        amplicon_tuple(fp=0, rp=1, fposition=16, rposition=23, size=39)
-    ]
-
-    t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG")
-
-    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == []
-
-    t = Dseqrecord("TATCGTGCACCTACCAAACCTCTCTCACTTGAAGTAATG", circular=True)
-
-    assert primer_pairs(t, [f, r], automaton=automaton, short=0) == [
-        amplicon_tuple(fp=0, rp=1, fposition=39, rposition=7, size=39)
     ]

--- a/tests/test_module_primer_screen.py
+++ b/tests/test_module_primer_screen.py
@@ -98,6 +98,10 @@ def test_contained():
 
     assert contained(1, 5, 6, 38, 1, circular=True) is False
 
+    # Overlaps but not contained
+    assert contained(1, 5, 2, 8, 39, circular=True) is False
+    assert contained(1, 5, 8, 2, 39, circular=True) is False
+
 
 def test_closest_pair_and_diff():
 

--- a/tests/test_module_primer_screen.py
+++ b/tests/test_module_primer_screen.py
@@ -132,6 +132,13 @@ def test_flanking_primer_pairs():
     ]
     assert result == answer
 
+    result = flanking_primer_pairs(pIL68, pl, target=(550, 1200), automaton=atm)
+
+    answer = [
+        amplicon_tuple(fp=1215, rp=594, fposition=266, rposition=1689, size=1474),
+        amplicon_tuple(fp=1215, rp=607, fposition=266, rposition=2157, size=1946),
+    ]
+
 
 def test_diff_primer_pairs():
 


### PR DESCRIPTION
Primer screen functions now work for circular templates. The topology is extracted from the circular property of the template.

flanking_primer_pairs and diff_primer_pairs now returns a list sorted by size of the potential PCR product.

Asserts to help the user calling the functions correctly.

There was a bug in the filtering of product sizes that would cause reporting the wrong primer pairs.




