### PR TITLE
Added more node operations that should generate a warning

### DIFF
--- a/src/pydna/snapgene_history_parser.py
+++ b/src/pydna/snapgene_history_parser.py
@@ -421,7 +421,15 @@ def _source_from_tree_node(  # noqa: C901
         products = oligonucleotide_hybridization(*primers, 10)
     elif node.operation == "invalid":
         return None, []
-    elif node.operation in ["remove", "insert", "replace","insertReverseTranslation","insertCodons","insertRestrictionSite","insertFeature"]:
+    elif node.operation in [
+        "remove",
+        "insert",
+        "replace",
+        "insertReverseTranslation",
+        "insertCodons",
+        "insertRestrictionSite",
+        "insertFeature",
+    ]:
         warnings.warn(
             "Manual editing of sequences not supported",
             category=SnapgeneHistoryParserWarning,

--- a/src/pydna/snapgene_history_parser.py
+++ b/src/pydna/snapgene_history_parser.py
@@ -421,7 +421,7 @@ def _source_from_tree_node(  # noqa: C901
         products = oligonucleotide_hybridization(*primers, 10)
     elif node.operation == "invalid":
         return None, []
-    elif node.operation in ["remove", "insert", "replace"]:
+    elif node.operation in ["remove", "insert", "replace","insertReverseTranslation","insertCodons","insertRestrictionSite","insertFeature"]:
         warnings.warn(
             "Manual editing of sequences not supported",
             category=SnapgeneHistoryParserWarning,


### PR DESCRIPTION
This addresses Issue [#623](https://github.com/pydna-group/pydna/issues/623) 

Snapgene supports different types of manual editing from within the GUI, such as Insert Codons.  This is obviously not a supported cloning operation.  So it should not be included in Dseqrecord.sources.  But right now it creates an exception.  I think the best option is to ignore the operation (and all children) and print a warning.

The operations I know of are:
insertCodons
insertRestrictionSite
insertFeature
insertReverseTranslation