### PR TITLE
Add ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,25 @@
 default_stages: [pre-commit]
 
 repos:
+  # Lint and format with the project's own ruff (run through uv), so the hook
+  # always uses the exact same version as CI — no drift between a pinned hook
+  # and the uv-managed tool. Catches problems before the commit exists instead
+  # of waiting for CI to reject the push.
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check --fix
+        language: system
+        files: ^(src|tests)/.*\.pyi?$
+        require_serial: true
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        files: ^(src|tests)/.*\.pyi?$
+        require_serial: true
+
   # Strip volatile metadata (execution counts, timestamps) from notebooks so
   # git history does not fill up with churn. Outputs are kept for the docs.
   - repo: local

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: setup dev build test test-all lint fmt clean
+.PHONY: setup dev build test test-all lint fmt clean hooks
 
 setup:
 	uv sync --all-extras --group test --group dev
+	uv run pre-commit install
+
+hooks:
+	uv run pre-commit install
 
 dev:
 	uv run python -c "import pydna; print(f'pydna {pydna.__version__} ready')"

--- a/README.md
+++ b/README.md
@@ -414,12 +414,16 @@ required for the tests to pass:
 # Install all runtime extras plus the dev and test tool groups
 uv sync --all-extras --group test --group dev
 
+# Install the git pre-commit hooks (ruff + nbstripout). Do this once per clone.
+uv run pre-commit install
+
 # Run anything inside the environment with `uv run`, e.g. the tests
 uv run python run_test.py
 ```
 
 A `Makefile` wraps the common tasks: `make setup`, `make test`, `make test-all`,
-`make lint`, `make fmt`, `make build`, `make clean`.
+`make lint`, `make fmt`, `make build`, `make clean`. `make setup` also installs
+the pre-commit hooks (or run `make hooks` on its own).
 
 #### Contributing code 💻
 
@@ -427,7 +431,7 @@ A `Makefile` wraps the common tasks: `make setup`, `make test`, `make test-all`,
 2. Add the necessary tests in `tests/`.
 3. Run the tests from the root directory with `python run_test.py`.
    > **TIP:** You can run a particular test file with `pytest -vs test_file.py` (`-v` for verbose and `-s` to see print statements in the test). If you want to run just a single test, you can use `pytest -vs -k test_name`, where `test_name` is the name of the test function.
-4. Before committing, format and lint with `make fmt` and `make lint` (both run `ruff`). CI runs the same `ruff` checks, so code must be formatted and lint-clean to pass.
+4. With the pre-commit hooks installed (see above), `ruff` lint/format and notebook stripping run automatically on every commit, so you catch issues before CI does. You can also run them by hand with `make fmt` and `make lint`, or against everything with `uv run pre-commit run --all-files`. CI runs the same `ruff` checks, so code must be formatted and lint-clean to pass.
 5. Push the changes to your fork
 
 > **TIP:** The continuous integration pipeline also runs doctests. These are tests that validate that the docstring examples are correct. For example, the docstring of the function `pydna.utils.smallest_rotation` looks like this:

--- a/README.md
+++ b/README.md
@@ -427,12 +427,13 @@ the pre-commit hooks (or run `make hooks` on its own).
 
 #### Contributing code 💻
 
-1. Make your changes.
-2. Add the necessary tests in `tests/`.
-3. Run the tests from the root directory with `python run_test.py`.
+1. Fork the pydna repository.
+2. Make your changes in the fork.
+3. Add the necessary tests in `tests/`.
+4. Run the tests from the root directory with `python run_test.py`.
    > **TIP:** You can run a particular test file with `pytest -vs test_file.py` (`-v` for verbose and `-s` to see print statements in the test). If you want to run just a single test, you can use `pytest -vs -k test_name`, where `test_name` is the name of the test function.
-4. With the pre-commit hooks installed (see above), `ruff` lint/format and notebook stripping run automatically on every commit, so you catch issues before CI does. You can also run them by hand with `make fmt` and `make lint`, or against everything with `uv run pre-commit run --all-files`. CI runs the same `ruff` checks, so code must be formatted and lint-clean to pass.
-5. Push the changes to your fork
+5. With the pre-commit hooks installed (see above), `ruff` lint/format and notebook stripping run automatically on every commit, so you catch issues before CI does. You can also run them by hand with `make fmt` and `make lint`, or against everything with `uv run pre-commit run --all-files`. CI runs the same `ruff` checks, so code must be formatted and lint-clean to pass.
+6. Push the changes to your fork
 
 > **TIP:** The continuous integration pipeline also runs doctests. These are tests that validate that the docstring examples are correct. For example, the docstring of the function `pydna.utils.smallest_rotation` looks like this:
 > ```python


### PR DESCRIPTION
Continuation of #665.

- add ruff check + ruff format pre-commit hooks as local hooks that run the project's ruff via 'uv run', so they always match CI's ruff (no version drift with a pinned hook)
- README: restore the 'uv run pre-commit install' step and explain the hooks run ruff + nbstripout on commit
- Makefile: 'make setup' now installs the hooks; add a 'make hooks' target

Lets contributors catch lint/format issues before committing instead of waiting for CI.